### PR TITLE
task/runner: Avoid re-running poison tasks

### DIFF
--- a/task/runner.go
+++ b/task/runner.go
@@ -144,9 +144,12 @@ func (r *runner) handleTask(ctx context.Context, taskInfo data.TaskInfo) (output
 
 	handler, ok := r.TaskHandlers[strings.ToLower(taskType)]
 	if !ok {
-		return nil, UnretriableError{fmt.Errorf("unknown task type=%q id=%s", taskType, taskID)}
+		return nil, UnretriableError{fmt.Errorf("unknown task type=%q", taskType)}
 	}
 
+	if taskCtx.Status.Phase == "running" {
+		return nil, UnretriableError{errors.New("task has already been started before")}
+	}
 	err = r.lapi.UpdateTaskStatus(taskID, "running", 0)
 	if err != nil {
 		glog.Errorf("Error updating task progress type=%q id=%s err=%q unretriable=%v", taskType, taskID, err, IsUnretriable(err))


### PR DESCRIPTION
We have some tasks that are being re-executed
over and over again since they get stuck in the
task-runner logic. We should fix the root cause
of those, but to avoid the problem from getting
worse we should also avoid re-running these tasks
over and over again.

This fixes that by not even starting tasks that we
find out had already been started (phase=running).

This is related to #19