### PR TITLE
task: Tweak profiles for HLS playback prepare task

### DIFF
--- a/task/prepare.go
+++ b/task/prepare.go
@@ -12,11 +12,16 @@ import (
 	"github.com/livepeer/stream-tester/segmenter"
 )
 
+const (
+	minVideoBitrate         = 100_000
+	absoluteMinVideoBitrate = 5_000
+)
+
 var allProfiles = []livepeerAPI.Profile{
 	{
 		Name:    "240p0",
 		Fps:     0,
-		Bitrate: 250000,
+		Bitrate: 250_000,
 		Width:   426,
 		Height:  240,
 		Gop:     "2.0",
@@ -24,7 +29,7 @@ var allProfiles = []livepeerAPI.Profile{
 	{
 		Name:    "360p0",
 		Fps:     0,
-		Bitrate: 800000,
+		Bitrate: 800_000,
 		Width:   640,
 		Height:  360,
 		Gop:     "2.0",
@@ -32,7 +37,7 @@ var allProfiles = []livepeerAPI.Profile{
 	{
 		Name:    "480p0",
 		Fps:     0,
-		Bitrate: 1600000,
+		Bitrate: 1_600_000,
 		Width:   854,
 		Height:  480,
 		Gop:     "2.0",
@@ -40,7 +45,7 @@ var allProfiles = []livepeerAPI.Profile{
 	{
 		Name:    "720p0",
 		Fps:     0,
-		Bitrate: 3000000,
+		Bitrate: 3_000_000,
 		Width:   1280,
 		Height:  720,
 		Gop:     "2.0",
@@ -115,14 +120,24 @@ func getPlaybackProfiles(assetVideoSpec *livepeerAPI.AssetVideoSpec) ([]livepeer
 		}
 	}
 	if len(filtered) == 0 {
-		return []livepeerAPI.Profile{{
-			Name:    "low-bitrate",
-			Fps:     0,
-			Bitrate: int(video.Bitrate / 2),
-			Width:   video.Width,
-			Height:  video.Height,
-			Gop:     "2.0",
-		}}, nil
+		return []livepeerAPI.Profile{lowBitrateProfile(video)}, nil
 	}
 	return filtered, nil
+}
+
+func lowBitrateProfile(video *livepeerAPI.AssetTrack) livepeerAPI.Profile {
+	bitrate := int(video.Bitrate / 3)
+	if bitrate < minVideoBitrate && video.Bitrate > minVideoBitrate {
+		bitrate = minVideoBitrate
+	} else if bitrate < absoluteMinVideoBitrate {
+		bitrate = absoluteMinVideoBitrate
+	}
+	return livepeerAPI.Profile{
+		Name:    "low-bitrate",
+		Fps:     0,
+		Bitrate: bitrate,
+		Width:   video.Width,
+		Height:  video.Height,
+		Gop:     "2.0",
+	}
 }

--- a/task/prepare.go
+++ b/task/prepare.go
@@ -101,18 +101,18 @@ func Prepare(tctx *TaskContext, assetSpec *livepeerAPI.AssetSpec, file io.ReadSe
 }
 
 func getPlaybackProfiles(assetVideoSpec *livepeerAPI.AssetVideoSpec) ([]livepeerAPI.Profile, error) {
-	assetHeight := -1
+	var video *livepeerAPI.AssetTrack
 	for _, track := range assetVideoSpec.Tracks {
 		if track.Type == "video" {
-			assetHeight = track.Height
+			video = track
 		}
 	}
-	if assetHeight < 0 {
+	if video == nil {
 		return nil, fmt.Errorf("no video track found in asset spec")
 	}
 	filtered := make([]livepeerAPI.Profile, 0, len(allProfiles))
 	for _, profile := range allProfiles {
-		if profile.Height <= assetHeight {
+		if profile.Height <= video.Height && profile.Bitrate <= int(video.Bitrate) {
 			filtered = append(filtered, profile)
 		}
 	}

--- a/task/prepare.go
+++ b/task/prepare.go
@@ -116,7 +116,7 @@ func getPlaybackProfiles(assetVideoSpec *livepeerAPI.AssetVideoSpec) ([]livepeer
 	}
 	if len(filtered) == 0 {
 		return []livepeerAPI.Profile{{
-			Name:    "low",
+			Name:    "low-bitrate",
 			Fps:     0,
 			Bitrate: int(video.Bitrate / 2),
 			Width:   video.Width,

--- a/task/prepare.go
+++ b/task/prepare.go
@@ -138,6 +138,5 @@ func lowBitrateProfile(video *livepeerAPI.AssetTrack) livepeerAPI.Profile {
 		Bitrate: bitrate,
 		Width:   video.Width,
 		Height:  video.Height,
-		Gop:     "2.0",
 	}
 }

--- a/task/prepare.go
+++ b/task/prepare.go
@@ -12,17 +12,15 @@ import (
 	"github.com/livepeer/stream-tester/segmenter"
 )
 
-var profile240p = livepeerAPI.Profile{
-	Name:    "240p0",
-	Fps:     0,
-	Bitrate: 250000,
-	Width:   426,
-	Height:  240,
-	Gop:     "2.0",
-}
-
 var allProfiles = []livepeerAPI.Profile{
-	profile240p,
+	{
+		Name:    "240p0",
+		Fps:     0,
+		Bitrate: 250000,
+		Width:   426,
+		Height:  240,
+		Gop:     "2.0",
+	},
 	{
 		Name:    "360p0",
 		Fps:     0,
@@ -117,7 +115,14 @@ func getPlaybackProfiles(assetVideoSpec *livepeerAPI.AssetVideoSpec) ([]livepeer
 		}
 	}
 	if len(filtered) == 0 {
-		return []livepeerAPI.Profile{profile240p}, nil
+		return []livepeerAPI.Profile{{
+			Name:    "low",
+			Fps:     0,
+			Bitrate: int(video.Bitrate / 2),
+			Width:   video.Width,
+			Height:  video.Height,
+			Gop:     "2.0",
+		}}, nil
 	}
 	return filtered, nil
 }

--- a/task/prepare.go
+++ b/task/prepare.go
@@ -115,7 +115,7 @@ func getPlaybackProfiles(assetVideoSpec *livepeerAPI.AssetVideoSpec) ([]livepeer
 	}
 	filtered := make([]livepeerAPI.Profile, 0, len(allProfiles))
 	for _, profile := range allProfiles {
-		if profile.Height <= video.Height && profile.Bitrate <= int(video.Bitrate) {
+		if profile.Height <= video.Height && profile.Bitrate < int(video.Bitrate) {
 			filtered = append(filtered, profile)
 		}
 	}


### PR DESCRIPTION
This is to make some improvements to the profiles used for HLS playback preparation.

Specifically:
 - Do not include profiles with bitrate higher than the current video
 - Default to a profile equal to the current video but with half the bitratre, instead of the hardcoded 240p0

Thats it