### PR TITLE
clients/ipfs: Use CIDv1 for all IPFS uploads

### DIFF
--- a/clients/ipfs.go
+++ b/clients/ipfs.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"io"
+	"strings"
 	"time"
 
 	"github.com/golang/glog"
@@ -12,6 +13,8 @@ import (
 
 const (
 	pinataBaseUrl = "https://api.pinata.cloud"
+	jsonMimeType  = "application/json"
+	pinataOptions = `{"cidVersion":1}`
 )
 
 type IPFS interface {
@@ -59,9 +62,10 @@ type uploadResponse struct {
 func (p *pinataClient) PinContent(ctx context.Context, filename, fileContentType string, data io.Reader) (string, interface{}, error) {
 	parts := []part{
 		{"file", filename, fileContentType, data},
+		{"pinataOptions", "", jsonMimeType, strings.NewReader(pinataOptions)},
 	}
 	if p.filesMetadata != nil {
-		parts = append(parts, part{"pinataMetadata", "", "application/json", bytes.NewReader(p.filesMetadata)})
+		parts = append(parts, part{"pinataMetadata", "", jsonMimeType, bytes.NewReader(p.filesMetadata)})
 	}
 	body, contentType := multipartBody(parts)
 	defer body.Close()


### PR DESCRIPTION
It is the recommended approach for CIDs as it's
future-proof (hash alg is embedded in the CID)
and also because it's case insensitive and will
work better on all scenarios (like URLs).

It is weirdly not the default on Piñata yet, but
while it is not we can easily toggle it on our
export requests.

It does not break compatibility on anything that I can
think of.

Reference: https://docs.ipfs.io/how-to/best-practices-for-ipfs-builders/