### PR TITLE
task/progress: Add Progress Tracking to Transcode and Prepare

### DIFF
--- a/task/export.go
+++ b/task/export.go
@@ -47,7 +47,7 @@ func TaskExport(tctx *TaskContext) (*data.TaskOutput, error) {
 	tctx = tctx.WithContext(ctx)
 
 	content := NewReadCounter(file.Body)
-	go ReportProgress(ctx, tctx.lapi, tctx.Task.ID, size, content.Count)
+	go ReportProgress(ctx, tctx.lapi, tctx.Task.ID, size, content.Count, 0, 100)
 	output, err := uploadFile(tctx, asset, content)
 	if err != nil {
 		return nil, err

--- a/task/export.go
+++ b/task/export.go
@@ -47,7 +47,7 @@ func TaskExport(tctx *TaskContext) (*data.TaskOutput, error) {
 	tctx = tctx.WithContext(ctx)
 
 	content := NewReadCounter(file.Body)
-	go ReportProgress(ctx, tctx.lapi, tctx.Task.ID, size, content.Count, 0, 100)
+	go ReportProgress(ctx, tctx.lapi, tctx.Task.ID, size, content.Count, 0, 1)
 	output, err := uploadFile(tctx, asset, content)
 	if err != nil {
 		return nil, err

--- a/task/import.go
+++ b/task/import.go
@@ -137,9 +137,7 @@ func prepareImportedAsset(tctx *TaskContext, metadata *FileMetadata, fullPath st
 
 	playbackRecordingID, err := Prepare(tctx, metadata.AssetSpec, importedFile, 0.5)
 	if err != nil {
-		glog.Errorf("error preparing imported file assetId=%s err=%q", tctx.OutputAsset.ID, err)
-		// TODO: make these fatal once we're confident about prepare reliability
-		return "", nil
+		glog.Fatalf("error preparing imported file assetId=%s err=%q", tctx.OutputAsset.ID, err)
 	}
 	return playbackRecordingID, nil
 }

--- a/task/import.go
+++ b/task/import.go
@@ -41,10 +41,10 @@ func TaskImport(tctx *TaskContext) (*data.TaskOutput, error) {
 	)
 	// Temporarily skip preparing recorded streams while we figure out a bug in the orchestrators latest version.
 	isInputRecording := strings.HasPrefix(params.URL, "https://livepeercdn.") && strings.Contains(params.URL, "/recordings/")
-	if isInputRecording {
-		go ReportProgress(egCtx, tctx.lapi, tctx.Task.ID, size, mainReader.Count, 0, 100)
-	} else {
+	if !isInputRecording {
 		go ReportProgress(egCtx, tctx.lapi, tctx.Task.ID, size, mainReader.Count, 0, 50)
+	} else {
+		go ReportProgress(egCtx, tctx.lapi, tctx.Task.ID, size, mainReader.Count, 0, 100)
 	}
 	// Probe the source file to retrieve metadata
 	eg.Go(func() (err error) {
@@ -85,7 +85,7 @@ func TaskImport(tctx *TaskContext) (*data.TaskOutput, error) {
 		}
 		defer importedFile.Close()
 		// RecordStream on output file for HLS playback
-		playbackRecordingId, err = Prepare(tctx, metadata.AssetSpec, importedFile, 50)
+		playbackRecordingId, err = Prepare(tctx, metadata.AssetSpec, importedFile, *fileInfoReader.Size, 50)
 		if err != nil {
 			glog.Errorf("error preparing imported file assetId=%s err=%q", tctx.OutputAsset.ID, err)
 		}

--- a/task/import.go
+++ b/task/import.go
@@ -137,7 +137,8 @@ func prepareImportedAsset(tctx *TaskContext, metadata *FileMetadata, fullPath st
 
 	playbackRecordingID, err := Prepare(tctx, metadata.AssetSpec, importedFile, 0.5)
 	if err != nil {
-		glog.Fatalf("error preparing imported file assetId=%s err=%q", tctx.OutputAsset.ID, err)
+		glog.Errorf("error preparing imported file assetId=%s err=%q", tctx.OutputAsset.ID, err)
+		return "", err
 	}
 	return playbackRecordingID, nil
 }

--- a/task/import.go
+++ b/task/import.go
@@ -42,9 +42,9 @@ func TaskImport(tctx *TaskContext) (*data.TaskOutput, error) {
 	// Temporarily skip preparing recorded streams while we figure out a bug in the orchestrators latest version.
 	isInputRecording := strings.HasPrefix(params.URL, "https://livepeercdn.") && strings.Contains(params.URL, "/recordings/")
 	if !isInputRecording {
-		go ReportProgress(egCtx, tctx.lapi, tctx.Task.ID, size, mainReader.Count, 0, 50)
+		go ReportProgress(egCtx, tctx.lapi, tctx.Task.ID, size, mainReader.Count, 0, 0.5)
 	} else {
-		go ReportProgress(egCtx, tctx.lapi, tctx.Task.ID, size, mainReader.Count, 0, 100)
+		go ReportProgress(egCtx, tctx.lapi, tctx.Task.ID, size, mainReader.Count, 0, 1)
 	}
 	// Probe the source file to retrieve metadata
 	eg.Go(func() (err error) {
@@ -85,7 +85,7 @@ func TaskImport(tctx *TaskContext) (*data.TaskOutput, error) {
 		}
 		defer importedFile.Close()
 		// RecordStream on output file for HLS playback
-		playbackRecordingId, err = Prepare(tctx, metadata.AssetSpec, importedFile, *fileInfoReader.Size, 50)
+		playbackRecordingId, err = Prepare(tctx, metadata.AssetSpec, importedFile, 0.5)
 		if err != nil {
 			glog.Errorf("error preparing imported file assetId=%s err=%q", tctx.OutputAsset.ID, err)
 		}

--- a/task/prepare.go
+++ b/task/prepare.go
@@ -54,7 +54,7 @@ var allProfiles = []api.Profile{
 	},
 }
 
-func Prepare(tctx *TaskContext, assetSpec *api.AssetSpec, file io.ReadSeekCloser) (string, error) {
+func Prepare(tctx *TaskContext, assetSpec *livepeerAPI.AssetSpec, file io.ReadSeekCloser, reportProgressStartPercentage int) (string, error) {
 	var (
 		ctx     = tctx.Context
 		lapi    = tctx.lapi

--- a/task/prepare.go
+++ b/task/prepare.go
@@ -89,7 +89,7 @@ func Prepare(tctx *TaskContext, assetSpec *api.AssetSpec, file io.ReadSeekCloser
 		}
 	}
 
-	accumulator := NewSegmentSizeAccumulator()
+	accumulator := NewAccumulator()
 	progressCtx, cancelProgress := context.WithCancel(ctx)
 	defer cancelProgress()
 	go ReportProgress(progressCtx, lapi, tctx.Task.ID, assetSpec.Size, accumulator.Size, progressStart, 1)

--- a/task/prepare.go
+++ b/task/prepare.go
@@ -54,7 +54,7 @@ var allProfiles = []api.Profile{
 	},
 }
 
-func Prepare(tctx *TaskContext, assetSpec *livepeerAPI.AssetSpec, file io.ReadSeekCloser, size int64, reportProgressStartPercentage int) (string, error) {
+func Prepare(tctx *TaskContext, assetSpec *livepeerAPI.AssetSpec, file io.ReadSeekCloser, reportProgressStartPercentage int) (string, error) {
 	var (
 		ctx     = tctx.Context
 		lapi    = tctx.lapi
@@ -89,7 +89,7 @@ func Prepare(tctx *TaskContext, assetSpec *livepeerAPI.AssetSpec, file io.ReadSe
 		}
 	}
 
-	counter := NewSegmentCounter(size)
+	counter := NewSegmentCounter(int64(assetSpec.Size))
 	go ReportProgress(ctx, lapi, tctx.Task.ID, counter.size, counter.Count, reportProgressStartPercentage, 100)
 
 	for seg := range segmentsIn {

--- a/task/prepare.go
+++ b/task/prepare.go
@@ -64,11 +64,11 @@ func Prepare(tctx *TaskContext, assetSpec *api.AssetSpec, file io.ReadSeekCloser
 	streamName := fmt.Sprintf("vod_hls_recording_%s", assetId)
 	profiles, err := getPlaybackProfiles(assetSpec.VideoSpec)
 	if err != nil {
-		return "", nil
+		return "", err
 	}
 	stream, err := lapi.CreateStream(api.CreateStreamReq{Name: streamName, Record: true, Profiles: profiles})
 	if err != nil {
-		return "", nil
+		return "", err
 	}
 	defer lapi.DeleteStream(stream.ID)
 

--- a/task/probe.go
+++ b/task/probe.go
@@ -130,9 +130,9 @@ func toAssetTrack(stream *ffprobe.Stream) (*api.AssetTrack, error) {
 		if !supportedVideoCodecs[stream.CodecName] {
 			return nil, fmt.Errorf("unsupported video codec: %s", stream.CodecName)
 		}
-		if !supportedPixelFormats[stream.PixFmt] {
-			return nil, fmt.Errorf("unsupported video pixel format: %s", stream.PixFmt)
-		}
+		// if !supportedPixelFormats[stream.PixFmt] {
+		// 	return nil, fmt.Errorf("unsupported video pixel format: %s", stream.PixFmt)
+		// }
 	}
 
 	startTime, err := strconv.ParseFloat(stream.StartTime, 64)

--- a/task/probe.go
+++ b/task/probe.go
@@ -127,10 +127,10 @@ func toAssetTrack(stream *ffprobe.Stream) (*api.AssetTrack, error) {
 	} else if stream.CodecType == "audio" && !supportedAudioCodecs[stream.CodecName] {
 		return nil, fmt.Errorf("unsupported audio codec: %s", stream.CodecName)
 	} else if stream.CodecType == "video" {
-		if val, ok := supportedVideoCodecs[stream.CodecName]; ok && !val {
+		if !supportedVideoCodecs[stream.CodecName] {
 			return nil, fmt.Errorf("unsupported video codec: %s", stream.CodecName)
 		}
-		if val, ok := supportedPixelFormats[stream.PixFmt]; ok && !val {
+		if stream.PixFmt != "" && !supportedPixelFormats[stream.PixFmt] {
 			return nil, fmt.Errorf("unsupported video pixel format: %s", stream.PixFmt)
 		}
 	}

--- a/task/probe.go
+++ b/task/probe.go
@@ -127,12 +127,12 @@ func toAssetTrack(stream *ffprobe.Stream) (*api.AssetTrack, error) {
 	} else if stream.CodecType == "audio" && !supportedAudioCodecs[stream.CodecName] {
 		return nil, fmt.Errorf("unsupported audio codec: %s", stream.CodecName)
 	} else if stream.CodecType == "video" {
-		if !supportedVideoCodecs[stream.CodecName] {
+		if val, ok := supportedVideoCodecs[stream.CodecName]; ok && !val {
 			return nil, fmt.Errorf("unsupported video codec: %s", stream.CodecName)
 		}
-		// if !supportedPixelFormats[stream.PixFmt] {
-		// 	return nil, fmt.Errorf("unsupported video pixel format: %s", stream.PixFmt)
-		// }
+		if val, ok := supportedPixelFormats[stream.PixFmt]; ok && !val {
+			return nil, fmt.Errorf("unsupported video pixel format: %s", stream.PixFmt)
+		}
 	}
 
 	startTime, err := strconv.ParseFloat(stream.StartTime, 64)

--- a/task/progress.go
+++ b/task/progress.go
@@ -17,7 +17,7 @@ const minProgressReportInterval = 10 * time.Second
 const progressCheckInterval = 1 * time.Second
 
 func ReportProgress(ctx context.Context, lapi *api.Client, taskID string, size uint64, getCount func() uint64, startFraction, endFraction float64) {
-	glog.Infof(`Report Progress rev5 START taskID=%s size=%d count=%d startFraction=%f endFraction=%f"`, taskID, size, getCount(), startFraction, endFraction)
+	glog.Infof(`Report Progress rev6 START taskID=%s size=%d count=%d startFraction=%f endFraction=%f"`, taskID, size, getCount(), startFraction, endFraction)
 	if startFraction > endFraction || startFraction < 0 || endFraction < 0 || startFraction > 1 || endFraction > 1 {
 		glog.Errorf("Error reporting task progress taskID=%s startFraction=%f endFraction=%f", taskID, startFraction, endFraction)
 		return
@@ -42,13 +42,13 @@ func ReportProgress(ctx context.Context, lapi *api.Client, taskID string, size u
 			return
 		case <-timer.C:
 			progress := calcProgress(getCount(), size)
-			glog.Infof(`Report Progress rev5 COUNT taskID=%s count=%d size=%d progress=%f"`, taskID, getCount(), size, progress)
+			glog.Infof(`Report Progress rev6 COUNT taskID=%s count=%d size=%d progress=%f"`, taskID, getCount(), size, progress)
 			if time.Since(lastReport) < minProgressReportInterval &&
 				progressBucket(progress) == progressBucket(lastProgress) {
 				continue
 			}
 			scaledProgress := scaleProgress(progress, startFraction, endFraction)
-			glog.Infof(`Report Progress rev5 SCALE taskID=%s progress=%f scaledProgress=%f start=%f end=%f"`, taskID, progress, scaledProgress, startFraction, endFraction)
+			glog.Infof(`Report Progress rev6 SCALE taskID=%s progress=%f scaledProgress=%f start=%f end=%f"`, taskID, progress, scaledProgress, startFraction, endFraction)
 			if err := lapi.UpdateTaskStatus(taskID, "running", scaledProgress); err != nil {
 				glog.Errorf("Error updating task progress taskID=%s progress=%v err=%q", taskID, progress, err)
 				continue

--- a/task/progress.go
+++ b/task/progress.go
@@ -17,7 +17,7 @@ const minProgressReportInterval = 10 * time.Second
 const progressCheckInterval = 1 * time.Second
 
 func ReportProgress(ctx context.Context, lapi *api.Client, taskID string, size uint64, getCount func() uint64, startFraction, endFraction float64) {
-	glog.Infof(`Report Progress rev4 taskID=%s size=%d count=%d startFraction=%f endFraction=%f"`, taskID, size, getCount(), startFraction, endFraction)
+	glog.Infof(`Report Progress rev5 START taskID=%s size=%d count=%d startFraction=%f endFraction=%f"`, taskID, size, getCount(), startFraction, endFraction)
 	if startFraction > endFraction || startFraction < 0 || endFraction < 0 || startFraction > 1 || endFraction > 1 {
 		glog.Errorf("Error reporting task progress taskID=%s startFraction=%f endFraction=%f", taskID, startFraction, endFraction)
 		return
@@ -42,13 +42,13 @@ func ReportProgress(ctx context.Context, lapi *api.Client, taskID string, size u
 			return
 		case <-timer.C:
 			progress := calcProgress(getCount(), size)
-			glog.Infof(`Report Progress COUNT taskID=%s count=%d size=%d progress=%f"`, taskID, getCount(), size, progress)
+			glog.Infof(`Report Progress rev5 COUNT taskID=%s count=%d size=%d progress=%f"`, taskID, getCount(), size, progress)
 			if time.Since(lastReport) < minProgressReportInterval &&
 				progressBucket(progress) == progressBucket(lastProgress) {
 				continue
 			}
 			scaledProgress := scaleProgress(progress, startFraction, endFraction)
-			glog.Infof(`Report Progress SCALE taskID=%s progress=%f scaledProgress=%f start=%f end=%f"`, taskID, progress, scaledProgress, startFraction, endFraction)
+			glog.Infof(`Report Progress rev5 SCALE taskID=%s progress=%f scaledProgress=%f start=%f end=%f"`, taskID, progress, scaledProgress, startFraction, endFraction)
 			if err := lapi.UpdateTaskStatus(taskID, "running", scaledProgress); err != nil {
 				glog.Errorf("Error updating task progress taskID=%s progress=%v err=%q", taskID, progress, err)
 				continue
@@ -66,7 +66,7 @@ func calcProgress(count, size uint64) (val float64) {
 }
 
 func scaleProgress(progress, startFraction, endFraction float64) (val float64) {
-	val = startFraction + val*(endFraction-startFraction)
+	val = startFraction + progress*(endFraction-startFraction)
 	return
 }
 

--- a/task/progress.go
+++ b/task/progress.go
@@ -16,8 +16,8 @@ const minProgressReportInterval = 10 * time.Second
 const progressCheckInterval = 1 * time.Second
 
 func ReportProgress(ctx context.Context, lapi *livepeerAPI.Client, taskID string, size uint64, getCount func() uint64, startPercentage int, endPercentage int) {
-	startPercentage = int(math.Max(float64(startPercentage), 0)) // >= 0, <= 100, < endPercentage
-	endPercentage = int(math.Min(float64(endPercentage), 100))   // >= 0, <= 100, > startPercentage
+	startPercentage = int(math.Max(float64(startPercentage), 0)) // >= 0, <= 100, smaller than endPercentage
+	endPercentage = int(math.Min(float64(endPercentage), 100))   // >= 0, <= 100, larger than startPercentage
 	defer func() {
 		if r := recover(); r != nil {
 			glog.Errorf("Panic reporting task progress: value=%q stack:\n%s", r, string(debug.Stack()))
@@ -53,7 +53,7 @@ func ReportProgress(ctx context.Context, lapi *livepeerAPI.Client, taskID string
 
 func calcProgress(count, size uint64, startPercentage int, endPercentage int) (val float64) {
 	val = float64(count) / float64(size)
-	val = val * (float64(startPercentage) - float64(endPercentage))
+	val = val * (float64(endPercentage) - float64(startPercentage))
 	val = (val + float64(startPercentage)) / 100
 	val = math.Round(val*1000) / 1000
 	val = math.Min(val, 0.99)

--- a/task/progress.go
+++ b/task/progress.go
@@ -17,7 +17,6 @@ const minProgressReportInterval = 10 * time.Second
 const progressCheckInterval = 1 * time.Second
 
 func ReportProgress(ctx context.Context, lapi *api.Client, taskID string, size uint64, getCount func() uint64, startFraction, endFraction float64) {
-	glog.Infof(`Report Progress rev6 START taskID=%s size=%d count=%d startFraction=%f endFraction=%f"`, taskID, size, getCount(), startFraction, endFraction)
 	if startFraction > endFraction || startFraction < 0 || endFraction < 0 || startFraction > 1 || endFraction > 1 {
 		glog.Errorf("Error reporting task progress taskID=%s startFraction=%f endFraction=%f", taskID, startFraction, endFraction)
 		return
@@ -42,13 +41,11 @@ func ReportProgress(ctx context.Context, lapi *api.Client, taskID string, size u
 			return
 		case <-timer.C:
 			progress := calcProgress(getCount(), size)
-			glog.Infof(`Report Progress rev6 COUNT taskID=%s count=%d size=%d progress=%f"`, taskID, getCount(), size, progress)
 			if time.Since(lastReport) < minProgressReportInterval &&
 				progressBucket(progress) == progressBucket(lastProgress) {
 				continue
 			}
 			scaledProgress := scaleProgress(progress, startFraction, endFraction)
-			glog.Infof(`Report Progress rev6 SCALE taskID=%s progress=%f scaledProgress=%f start=%f end=%f"`, taskID, progress, scaledProgress, startFraction, endFraction)
 			if err := lapi.UpdateTaskStatus(taskID, "running", scaledProgress); err != nil {
 				glog.Errorf("Error updating task progress taskID=%s progress=%v err=%q", taskID, progress, err)
 				continue

--- a/task/progress.go
+++ b/task/progress.go
@@ -62,9 +62,8 @@ func calcProgress(count, size uint64) (val float64) {
 	return
 }
 
-func scaleProgress(progress, startFraction, endFraction float64) (val float64) {
-	val = startFraction + progress*(endFraction-startFraction)
-	return
+func scaleProgress(progress, startFraction, endFraction float64) float64 {
+	return startFraction + progress*(endFraction-startFraction)
 }
 
 func progressBucket(progress float64) int {

--- a/task/progress.go
+++ b/task/progress.go
@@ -17,7 +17,7 @@ const minProgressReportInterval = 10 * time.Second
 const progressCheckInterval = 1 * time.Second
 
 func ReportProgress(ctx context.Context, lapi *api.Client, taskID string, size uint64, getCount func() uint64, startFraction, endFraction float64) {
-	glog.Infof(`Report Progress rev3 taskID=%s size=%d count=%d startFraction=%f endFraction=%f"`, taskID, size, getCount(), startFraction, endFraction)
+	glog.Infof(`Report Progress rev4 taskID=%s size=%d count=%d startFraction=%f endFraction=%f"`, taskID, size, getCount(), startFraction, endFraction)
 	if startFraction > endFraction || startFraction < 0 || endFraction < 0 || startFraction > 1 || endFraction > 1 {
 		glog.Errorf("Error reporting task progress taskID=%s startFraction=%f endFraction=%f", taskID, startFraction, endFraction)
 		return

--- a/task/transcode.go
+++ b/task/transcode.go
@@ -117,20 +117,20 @@ func fileWriter(size int64) WriteSeekCloser {
 	}
 }
 
-type SegmentSizeAccumulator struct {
-	readSize uint64
+type Accumulator struct {
+	size uint64
 }
 
-func NewSegmentSizeAccumulator() *SegmentSizeAccumulator {
-	return &SegmentSizeAccumulator{}
+func NewAccumulator() *Accumulator {
+	return &Accumulator{}
 }
 
-func (a *SegmentSizeAccumulator) Size() uint64 {
-	return atomic.LoadUint64(&a.readSize)
+func (a *Accumulator) Size() uint64 {
+	return atomic.LoadUint64(&a.size)
 }
 
-func (a *SegmentSizeAccumulator) Accumulate(size uint64) {
-	atomic.AddUint64(&a.readSize, size)
+func (a *Accumulator) Accumulate(size uint64) {
+	atomic.AddUint64(&a.size, size)
 }
 
 func TaskTranscode(tctx *TaskContext) (*data.TaskOutput, error) {
@@ -188,7 +188,7 @@ func TaskTranscode(tctx *TaskContext) (*data.TaskOutput, error) {
 		}
 	}
 	err = nil
-	accumulator := NewSegmentSizeAccumulator()
+	accumulator := NewAccumulator()
 	progressCtx, cancelProgress := context.WithCancel(ctx)
 	defer cancelProgress()
 	go ReportProgress(progressCtx, lapi, tctx.Task.ID, uint64(sourceFileSize), accumulator.Size, 0, 0.5)

--- a/task/transcode.go
+++ b/task/transcode.go
@@ -125,12 +125,12 @@ func NewSegmentSizeAccumulator() *SegmentSizeAccumulator {
 	return &SegmentSizeAccumulator{}
 }
 
-func (c SegmentSizeAccumulator) Size() uint64 {
-	return atomic.LoadUint64(&c.readSize)
+func (a *SegmentSizeAccumulator) Size() uint64 {
+	return atomic.LoadUint64(&a.readSize)
 }
 
-func (c SegmentSizeAccumulator) Accumulate(size uint64) {
-	atomic.AddUint64(&c.readSize, size)
+func (a *SegmentSizeAccumulator) Accumulate(size uint64) {
+	atomic.AddUint64(&a.readSize, size)
 }
 
 func TaskTranscode(tctx *TaskContext) (*data.TaskOutput, error) {
@@ -261,7 +261,7 @@ out:
 	}
 	cancelProgress()
 	// RecordStream on output file for HLS playback
-	playbackRecordingId, err := Prepare(tctx, metadata.AssetSpec, ws.Reader(), 0.5)
+	playbackRecordingId, err := Prepare(tctx.WithContext(ctx), metadata.AssetSpec, ws.Reader(), 0.5)
 	if err != nil {
 		glog.Errorf("error preparing imported file assetId=%s err=%q", tctx.OutputAsset.ID, err)
 	}

--- a/task/transcode.go
+++ b/task/transcode.go
@@ -263,7 +263,7 @@ out:
 	// RecordStream on output file for HLS playback
 	playbackRecordingId, err := Prepare(tctx.WithContext(ctx), metadata.AssetSpec, ws.Reader(), 0.5)
 	if err != nil {
-		glog.Errorf("error preparing imported file assetId=%s err=%q", tctx.OutputAsset.ID, err)
+		glog.Fatalf("error preparing imported file assetId=%s err=%q", tctx.OutputAsset.ID, err)
 	}
 	assetSpec := *metadata.AssetSpec
 	assetSpec.PlaybackRecordingID = playbackRecordingId

--- a/task/transcode.go
+++ b/task/transcode.go
@@ -263,7 +263,8 @@ out:
 	// RecordStream on output file for HLS playback
 	playbackRecordingId, err := Prepare(tctx.WithContext(ctx), metadata.AssetSpec, ws.Reader(), 0.5)
 	if err != nil {
-		glog.Fatalf("error preparing imported file assetId=%s err=%q", tctx.OutputAsset.ID, err)
+		glog.Errorf("error preparing imported file assetId=%s err=%q", tctx.OutputAsset.ID, err)
+		return nil, err
 	}
 	assetSpec := *metadata.AssetSpec
 	assetSpec.PlaybackRecordingID = playbackRecordingId


### PR DESCRIPTION
https://github.com/livepeer/task-runner/issues/26 https://github.com/livepeer/task-runner/issues/40

Refactor `ReportProgress` logic to specify progress sub-window between 0 and 100 percent. Percentage progress of getCount/size is applied only to the sub-window of overall progress.

Track progress for `transcode` and `process` tasks using size of segments pushed relative to overall size of the file.

`transcode`/`process` and `import`/`process` tasks are 50-50 split between the progress bar, this is easily adjustable.

---

Makes Prepare sub-task failures fatal

---

Also fixes bug in `probe.go` which causes error when `video pixel format` could not be probed from file and is empty