### PR TITLE
task: Update go-api-client and stream-tester with fixes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/livepeer/go-livepeer v0.5.31
 	github.com/livepeer/joy4 v0.1.2-0.20220210094601-95e4d28f5f07
 	github.com/livepeer/livepeer-data v0.4.14
-	github.com/livepeer/stream-tester v0.12.10
+	github.com/livepeer/stream-tester v0.12.11
 	github.com/peterbourgon/ff v1.7.1
 	github.com/rabbitmq/amqp091-go v1.1.0
 	github.com/stretchr/testify v1.7.0

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.16
 
 require (
 	github.com/golang/glog v1.0.0
-	github.com/livepeer/go-api-client v0.2.0-beta
+	github.com/livepeer/go-api-client v0.2.0
 	github.com/livepeer/go-livepeer v0.5.31
 	github.com/livepeer/joy4 v0.1.2-0.20220210094601-95e4d28f5f07
 	github.com/livepeer/livepeer-data v0.4.14

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.16
 
 require (
 	github.com/golang/glog v1.0.0
-	github.com/livepeer/go-api-client v0.1.5
+	github.com/livepeer/go-api-client v0.2.0-beta
 	github.com/livepeer/go-livepeer v0.5.31
 	github.com/livepeer/joy4 v0.1.2-0.20220210094601-95e4d28f5f07
 	github.com/livepeer/livepeer-data v0.4.14

--- a/go.sum
+++ b/go.sum
@@ -708,8 +708,8 @@ github.com/livepeer/lpms v0.0.0-20220523122311-fc32eb80248c h1:LFwabjsjQU/bxVdUL
 github.com/livepeer/lpms v0.0.0-20220523122311-fc32eb80248c/go.mod h1:Hr/JhxxPDipOVd4ZrGYWrdJfpVF8/SEI0nNr2ctAlkM=
 github.com/livepeer/m3u8 v0.11.1 h1:VkUJzfNTyjy9mqsgp5JPvouwna8wGZMvd/gAfT5FinU=
 github.com/livepeer/m3u8 v0.11.1/go.mod h1:IUqAtwWPAG2CblfQa4SVzTQoDcEMPyfNOaBSxqHMS04=
-github.com/livepeer/stream-tester v0.12.10 h1:M7W4TPO7tGvOaQHkgx207FeCg7D45SstHdq3kzBMiMk=
-github.com/livepeer/stream-tester v0.12.10/go.mod h1:UJG9vkEJuBcbEFl0AUQYu1mahBOiVRZkF/FAcvJ4nJQ=
+github.com/livepeer/stream-tester v0.12.11 h1:RuHOIC5pFZy9XUbGqWLuiFoqh4UHBUp6q+//IxEOme0=
+github.com/livepeer/stream-tester v0.12.11/go.mod h1:UJG9vkEJuBcbEFl0AUQYu1mahBOiVRZkF/FAcvJ4nJQ=
 github.com/magiconair/properties v1.8.5/go.mod h1:y3VJvCyxH9uVvJTWEGAELF3aiYNyPKd5NZ3oSwXrF60=
 github.com/mailru/easyjson v0.0.0-20190614124828-94de47d64c63/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
 github.com/mailru/easyjson v0.0.0-20190626092158-b2ccc519800e/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=

--- a/go.sum
+++ b/go.sum
@@ -693,8 +693,8 @@ github.com/labstack/gommon v0.3.0/go.mod h1:MULnywXg0yavhxWKc+lOruYdAhDwPK9wf0OL
 github.com/leanovate/gopter v0.2.9/go.mod h1:U2L/78B+KVFIx2VmW6onHJQzXtFb+p5y3y2Sh+Jxxv8=
 github.com/lib/pq v1.0.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
 github.com/lib/pq v1.8.0/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
-github.com/livepeer/go-api-client v0.2.0-beta h1:AmQyAi/EmC8S1HsUHw3d9lmoeDuDuT0BrgdXoL+io6g=
-github.com/livepeer/go-api-client v0.2.0-beta/go.mod h1:FPgo6hPAEQkWS/Bmepdm+O/LWfurbmym93ghzLueTUo=
+github.com/livepeer/go-api-client v0.2.0 h1:s4uR619KRNZsVLYGNBIp2wKr7ErE2GEGdfpljcACao4=
+github.com/livepeer/go-api-client v0.2.0/go.mod h1:FPgo6hPAEQkWS/Bmepdm+O/LWfurbmym93ghzLueTUo=
 github.com/livepeer/go-livepeer v0.5.31 h1:LcN+qDnqWRws7fdVYc4ucZPVcLQRs2tehUYCQVnlnRw=
 github.com/livepeer/go-livepeer v0.5.31/go.mod h1:cpBikcGWApkx0cyR0Ht+uAym7j3uAwXGpPbvaOA8XUU=
 github.com/livepeer/joy4 v0.1.2-0.20191121080656-b2fea45cbded/go.mod h1:xkDdm+akniYxVT9KW1Y2Y7Hso6aW+rZObz3nrA9yTHw=

--- a/go.sum
+++ b/go.sum
@@ -693,8 +693,8 @@ github.com/labstack/gommon v0.3.0/go.mod h1:MULnywXg0yavhxWKc+lOruYdAhDwPK9wf0OL
 github.com/leanovate/gopter v0.2.9/go.mod h1:U2L/78B+KVFIx2VmW6onHJQzXtFb+p5y3y2Sh+Jxxv8=
 github.com/lib/pq v1.0.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
 github.com/lib/pq v1.8.0/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
-github.com/livepeer/go-api-client v0.1.5 h1:eSiYokcg11L3uexhXefV8OJs2oB2dvsI1gGZcGnf+TM=
-github.com/livepeer/go-api-client v0.1.5/go.mod h1:FPgo6hPAEQkWS/Bmepdm+O/LWfurbmym93ghzLueTUo=
+github.com/livepeer/go-api-client v0.2.0-beta h1:AmQyAi/EmC8S1HsUHw3d9lmoeDuDuT0BrgdXoL+io6g=
+github.com/livepeer/go-api-client v0.2.0-beta/go.mod h1:FPgo6hPAEQkWS/Bmepdm+O/LWfurbmym93ghzLueTUo=
 github.com/livepeer/go-livepeer v0.5.31 h1:LcN+qDnqWRws7fdVYc4ucZPVcLQRs2tehUYCQVnlnRw=
 github.com/livepeer/go-livepeer v0.5.31/go.mod h1:cpBikcGWApkx0cyR0Ht+uAym7j3uAwXGpPbvaOA8XUU=
 github.com/livepeer/joy4 v0.1.2-0.20191121080656-b2fea45cbded/go.mod h1:xkDdm+akniYxVT9KW1Y2Y7Hso6aW+rZObz3nrA9yTHw=

--- a/task/errors.go
+++ b/task/errors.go
@@ -3,7 +3,7 @@ package task
 import (
 	"errors"
 
-	livepeerAPI "github.com/livepeer/go-api-client"
+	api "github.com/livepeer/go-api-client"
 )
 
 type UnretriableError struct{ error }
@@ -13,6 +13,6 @@ func (e UnretriableError) Error() string { return e.error.Error() }
 func (e UnretriableError) Unwrap() error { return e.error }
 
 func IsUnretriable(err error) bool {
-	return errors.Is(err, livepeerAPI.ErrNotExists) ||
+	return errors.Is(err, api.ErrNotExists) ||
 		errors.As(err, &UnretriableError{})
 }

--- a/task/export.go
+++ b/task/export.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 
 	"github.com/golang/glog"
-	livepeerAPI "github.com/livepeer/go-api-client"
+	api "github.com/livepeer/go-api-client"
 	"github.com/livepeer/livepeer-data/pkg/data"
 	"github.com/livepeer/task-runner/clients"
 )
@@ -60,7 +60,7 @@ type internalMetadata struct {
 	Pinata   interface{} `json:"pinata"`
 }
 
-func uploadFile(tctx *TaskContext, asset *livepeerAPI.Asset, content io.Reader) (*data.ExportTaskOutput, error) {
+func uploadFile(tctx *TaskContext, asset *api.Asset, content io.Reader) (*data.ExportTaskOutput, error) {
 	params := tctx.Task.Params.Export
 	contentType := "video/" + asset.VideoSpec.Format
 	if c := params.Custom; c != nil {
@@ -118,16 +118,16 @@ func uploadFile(tctx *TaskContext, asset *livepeerAPI.Asset, content io.Reader) 
 	}, nil
 }
 
-func saveNFTMetadata(tctx *TaskContext, ipfs clients.IPFS, asset *livepeerAPI.Asset, videoCID string) (string, error) {
+func saveNFTMetadata(tctx *TaskContext, ipfs clients.IPFS, asset *api.Asset, videoCID string) (string, error) {
 	params := tctx.Task.Params.Export.IPFS
 	template := params.NFTMetadataTemplate
-	if template == livepeerAPI.NFTMetadataTemplatePlayer && asset.PlaybackRecordingID == "" {
+	if template == api.NFTMetadataTemplatePlayer && asset.PlaybackRecordingID == "" {
 		return "", fmt.Errorf("cannot create player NFT for asset without playback URL")
 	}
 	if template == "" {
-		template = livepeerAPI.NFTMetadataTemplatePlayer
+		template = api.NFTMetadataTemplatePlayer
 		if asset.PlaybackRecordingID == "" {
-			template = livepeerAPI.NFTMetadataTemplateFile
+			template = api.NFTMetadataTemplateFile
 		}
 	}
 	nftMetadata := nftMetadata(asset, videoCID, template, tctx.ExportTaskConfig)
@@ -146,12 +146,12 @@ func saveNFTMetadata(tctx *TaskContext, ipfs clients.IPFS, asset *livepeerAPI.As
 	return cid, nil
 }
 
-func nftMetadata(asset *livepeerAPI.Asset, videoCID string, template livepeerAPI.NFTMetadataTemplate, config ExportTaskConfig) map[string]interface{} {
+func nftMetadata(asset *api.Asset, videoCID string, template api.NFTMetadataTemplate, config ExportTaskConfig) map[string]interface{} {
 	videoUrl := "ipfs://" + videoCID
 	switch template {
 	default:
 		fallthrough
-	case livepeerAPI.NFTMetadataTemplatePlayer:
+	case api.NFTMetadataTemplatePlayer:
 		return map[string]interface{}{
 			"name":          asset.Name,
 			"description":   fmt.Sprintf("Livepeer video from asset %q", asset.Name),
@@ -164,7 +164,7 @@ func nftMetadata(asset *livepeerAPI.Asset, videoCID string, template livepeerAPI
 				"com.livepeer.playbackId": asset.PlaybackID,
 			},
 		}
-	case livepeerAPI.NFTMetadataTemplateFile:
+	case api.NFTMetadataTemplateFile:
 		return map[string]interface{}{
 			"name":          asset.Name,
 			"description":   fmt.Sprintf("Livepeer video from asset %q", asset.Name),

--- a/task/import.go
+++ b/task/import.go
@@ -12,7 +12,7 @@ import (
 	"strings"
 
 	"github.com/golang/glog"
-	livepeerAPI "github.com/livepeer/go-api-client"
+	api "github.com/livepeer/go-api-client"
 	"github.com/livepeer/go-livepeer/drivers"
 	"github.com/livepeer/livepeer-data/pkg/data"
 	"golang.org/x/sync/errgroup"
@@ -96,7 +96,7 @@ func TaskImport(tctx *TaskContext) (*data.TaskOutput, error) {
 	}}, nil
 }
 
-func getFile(ctx context.Context, osSess drivers.OSSession, params livepeerAPI.ImportTaskParams) (name string, size uint64, content io.ReadCloser, err error) {
+func getFile(ctx context.Context, osSess drivers.OSSession, params api.ImportTaskParams) (name string, size uint64, content io.ReadCloser, err error) {
 	if upedObjKey := params.UploadedObjectKey; upedObjKey != "" {
 		// TODO: We should simply "move" the file in case of direct import since we
 		// know the file is already in the object store. Independently, we also have

--- a/task/import_test.go
+++ b/task/import_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"time"
 
-	livepeerAPI "github.com/livepeer/go-api-client"
+	api "github.com/livepeer/go-api-client"
 	"github.com/livepeer/go-livepeer/drivers"
 	"github.com/stretchr/testify/assert"
 )
@@ -31,7 +31,7 @@ func TestImport(t *testing.T) {
 
 	url := "https://eric-test-livepeer.s3.amazonaws.com/bbbx3_720.mp4"
 
-	var task *livepeerAPI.Task
+	var task *api.Task
 	err := json.Unmarshal([]byte(`{"params":{"import":{"url":"`+url+`"}}}`), &task)
 	assert.NoError(err)
 	os, err := drivers.ParseOSURL(osPath, true)
@@ -40,7 +40,7 @@ func TestImport(t *testing.T) {
 	result, err := TaskImport(&TaskContext{
 		Context:     ctx,
 		Task:        task,
-		OutputAsset: &livepeerAPI.Asset{PlaybackID: "test-playback-id"},
+		OutputAsset: &api.Asset{PlaybackID: "test-playback-id"},
 		outputOS:    os.NewSession("test_import_bbb"),
 	})
 	assert.NoError(err)

--- a/task/prepare.go
+++ b/task/prepare.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	"github.com/golang/glog"
-	lp_api "github.com/livepeer/go-api-client"
+	api "github.com/livepeer/go-api-client"
 	"github.com/livepeer/stream-tester/model"
 	"github.com/livepeer/stream-tester/segmenter"
 )
@@ -17,7 +17,7 @@ const (
 	absoluteMinVideoBitrate = 5_000
 )
 
-var allProfiles = []lp_api.Profile{
+var allProfiles = []api.Profile{
 	{
 		Name:    "240p0",
 		Fps:     0,
@@ -52,7 +52,7 @@ var allProfiles = []lp_api.Profile{
 	},
 }
 
-func Prepare(tctx *TaskContext, assetSpec *lp_api.AssetSpec, file io.ReadSeekCloser) (string, error) {
+func Prepare(tctx *TaskContext, assetSpec *api.AssetSpec, file io.ReadSeekCloser) (string, error) {
 	var (
 		ctx     = tctx.Context
 		lapi    = tctx.lapi
@@ -64,7 +64,7 @@ func Prepare(tctx *TaskContext, assetSpec *lp_api.AssetSpec, file io.ReadSeekClo
 	if err != nil {
 		return "", nil
 	}
-	stream, err := lapi.CreateStream(lp_api.CreateStreamReq{Name: streamName, Record: true, Profiles: profiles})
+	stream, err := lapi.CreateStream(api.CreateStreamReq{Name: streamName, Record: true, Profiles: profiles})
 	if err != nil {
 		return "", nil
 	}
@@ -114,8 +114,8 @@ func Prepare(tctx *TaskContext, assetSpec *lp_api.AssetSpec, file io.ReadSeekClo
 	return stream.ID, nil
 }
 
-func getPlaybackProfiles(assetVideoSpec *lp_api.AssetVideoSpec) ([]lp_api.Profile, error) {
-	var video *lp_api.AssetTrack
+func getPlaybackProfiles(assetVideoSpec *api.AssetVideoSpec) ([]api.Profile, error) {
+	var video *api.AssetTrack
 	for _, track := range assetVideoSpec.Tracks {
 		if track.Type == "video" {
 			video = track
@@ -124,26 +124,26 @@ func getPlaybackProfiles(assetVideoSpec *lp_api.AssetVideoSpec) ([]lp_api.Profil
 	if video == nil {
 		return nil, fmt.Errorf("no video track found in asset spec")
 	}
-	filtered := make([]lp_api.Profile, 0, len(allProfiles))
+	filtered := make([]api.Profile, 0, len(allProfiles))
 	for _, profile := range allProfiles {
 		if profile.Height <= video.Height && profile.Bitrate < int(video.Bitrate) {
 			filtered = append(filtered, profile)
 		}
 	}
 	if len(filtered) == 0 {
-		return []lp_api.Profile{lowBitrateProfile(video)}, nil
+		return []api.Profile{lowBitrateProfile(video)}, nil
 	}
 	return filtered, nil
 }
 
-func lowBitrateProfile(video *lp_api.AssetTrack) lp_api.Profile {
+func lowBitrateProfile(video *api.AssetTrack) api.Profile {
 	bitrate := int(video.Bitrate / 3)
 	if bitrate < minVideoBitrate && video.Bitrate > minVideoBitrate {
 		bitrate = minVideoBitrate
 	} else if bitrate < absoluteMinVideoBitrate {
 		bitrate = absoluteMinVideoBitrate
 	}
-	return lp_api.Profile{
+	return api.Profile{
 		Name:    "low-bitrate",
 		Fps:     0,
 		Bitrate: bitrate,

--- a/task/prepare.go
+++ b/task/prepare.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	"github.com/golang/glog"
-	livepeerAPI "github.com/livepeer/go-api-client"
+	lp_api "github.com/livepeer/go-api-client"
 	"github.com/livepeer/stream-tester/model"
 	"github.com/livepeer/stream-tester/segmenter"
 )
@@ -17,7 +17,7 @@ const (
 	absoluteMinVideoBitrate = 5_000
 )
 
-var allProfiles = []livepeerAPI.Profile{
+var allProfiles = []lp_api.Profile{
 	{
 		Name:    "240p0",
 		Fps:     0,
@@ -52,7 +52,7 @@ var allProfiles = []livepeerAPI.Profile{
 	},
 }
 
-func Prepare(tctx *TaskContext, assetSpec *livepeerAPI.AssetSpec, file io.ReadSeekCloser) (string, error) {
+func Prepare(tctx *TaskContext, assetSpec *lp_api.AssetSpec, file io.ReadSeekCloser) (string, error) {
 	var (
 		ctx     = tctx.Context
 		lapi    = tctx.lapi
@@ -64,7 +64,7 @@ func Prepare(tctx *TaskContext, assetSpec *livepeerAPI.AssetSpec, file io.ReadSe
 	if err != nil {
 		return "", nil
 	}
-	stream, err := lapi.CreateStreamEx2(streamName, true, "", nil, profiles...)
+	stream, err := lapi.CreateStream(lp_api.CreateStreamReq{Name: streamName, Record: true, Profiles: profiles})
 	if err != nil {
 		return "", nil
 	}
@@ -98,7 +98,7 @@ func Prepare(tctx *TaskContext, assetSpec *livepeerAPI.AssetSpec, file io.ReadSe
 		}
 		glog.V(model.VERBOSE).Infof("Got segment seqNo=%d pts=%s dur=%s data len bytes=%d\n", seg.SeqNo, seg.Pts, seg.Duration, len(seg.Data))
 		started := time.Now()
-		_, err = lapi.PushSegment(stream.ID, seg.SeqNo, seg.Duration, seg.Data, contentResolution)
+		_, err = lapi.PushSegmentR(stream.ID, seg.SeqNo, seg.Duration, seg.Data, contentResolution)
 		if err != nil {
 			glog.Errorf("Error while segment push for prepare err=%v\n", err)
 			break
@@ -111,8 +111,8 @@ func Prepare(tctx *TaskContext, assetSpec *livepeerAPI.AssetSpec, file io.ReadSe
 	return stream.ID, nil
 }
 
-func getPlaybackProfiles(assetVideoSpec *livepeerAPI.AssetVideoSpec) ([]livepeerAPI.Profile, error) {
-	var video *livepeerAPI.AssetTrack
+func getPlaybackProfiles(assetVideoSpec *lp_api.AssetVideoSpec) ([]lp_api.Profile, error) {
+	var video *lp_api.AssetTrack
 	for _, track := range assetVideoSpec.Tracks {
 		if track.Type == "video" {
 			video = track
@@ -121,26 +121,26 @@ func getPlaybackProfiles(assetVideoSpec *livepeerAPI.AssetVideoSpec) ([]livepeer
 	if video == nil {
 		return nil, fmt.Errorf("no video track found in asset spec")
 	}
-	filtered := make([]livepeerAPI.Profile, 0, len(allProfiles))
+	filtered := make([]lp_api.Profile, 0, len(allProfiles))
 	for _, profile := range allProfiles {
 		if profile.Height <= video.Height && profile.Bitrate < int(video.Bitrate) {
 			filtered = append(filtered, profile)
 		}
 	}
 	if len(filtered) == 0 {
-		return []livepeerAPI.Profile{lowBitrateProfile(video)}, nil
+		return []lp_api.Profile{lowBitrateProfile(video)}, nil
 	}
 	return filtered, nil
 }
 
-func lowBitrateProfile(video *livepeerAPI.AssetTrack) livepeerAPI.Profile {
+func lowBitrateProfile(video *lp_api.AssetTrack) lp_api.Profile {
 	bitrate := int(video.Bitrate / 3)
 	if bitrate < minVideoBitrate && video.Bitrate > minVideoBitrate {
 		bitrate = minVideoBitrate
 	} else if bitrate < absoluteMinVideoBitrate {
 		bitrate = absoluteMinVideoBitrate
 	}
-	return livepeerAPI.Profile{
+	return lp_api.Profile{
 		Name:    "low-bitrate",
 		Fps:     0,
 		Bitrate: bitrate,

--- a/task/progress.go
+++ b/task/progress.go
@@ -8,7 +8,7 @@ import (
 	"time"
 
 	"github.com/golang/glog"
-	livepeerAPI "github.com/livepeer/go-api-client"
+	api "github.com/livepeer/go-api-client"
 )
 
 var progressReportBuckets = []float64{0, 0.25, 0.5, 0.75, 1}
@@ -16,7 +16,7 @@ var progressReportBuckets = []float64{0, 0.25, 0.5, 0.75, 1}
 const minProgressReportInterval = 10 * time.Second
 const progressCheckInterval = 1 * time.Second
 
-func ReportProgress(ctx context.Context, lapi *livepeerAPI.Client, taskID string, size uint64, getCount func() uint64) {
+func ReportProgress(ctx context.Context, lapi *api.Client, taskID string, size uint64, getCount func() uint64) {
 	defer func() {
 		if r := recover(); r != nil {
 			glog.Errorf("Panic reporting task progress: value=%q stack:\n%s", r, string(debug.Stack()))

--- a/task/runner.go
+++ b/task/runner.go
@@ -9,7 +9,7 @@ import (
 	"time"
 
 	"github.com/golang/glog"
-	livepeerAPI "github.com/livepeer/go-api-client"
+	api "github.com/livepeer/go-api-client"
 	"github.com/livepeer/go-livepeer/drivers"
 	"github.com/livepeer/livepeer-data/pkg/data"
 	"github.com/livepeer/livepeer-data/pkg/event"
@@ -35,8 +35,8 @@ type TaskContext struct {
 	context.Context
 	*runner
 	data.TaskInfo
-	*livepeerAPI.Task
-	InputAsset, OutputAsset *livepeerAPI.Asset
+	*api.Task
+	InputAsset, OutputAsset *api.Asset
 	inputOS, outputOS       drivers.OSSession
 }
 
@@ -56,7 +56,7 @@ type RunnerOptions struct {
 	AMQPUri            string
 	ExchangeName       string
 	QueueName          string
-	LivepeerAPIOptions livepeerAPI.ClientOptions
+	LivepeerAPIOptions api.ClientOptions
 	ExportTaskConfig
 
 	TaskHandlers map[string]TaskHandler
@@ -68,7 +68,7 @@ func NewRunner(opts RunnerOptions) Runner {
 	}
 	return &runner{
 		RunnerOptions: opts,
-		lapi:          livepeerAPI.NewAPIClient(opts.LivepeerAPIOptions),
+		lapi:          api.NewAPIClient(opts.LivepeerAPIOptions),
 		ipfs: clients.NewPinataClientJWT(opts.PinataAccessToken, map[string]string{
 			"apiServer": opts.LivepeerAPIOptions.Server,
 			"createdBy": clients.UserAgent,
@@ -79,7 +79,7 @@ func NewRunner(opts RunnerOptions) Runner {
 type runner struct {
 	RunnerOptions
 
-	lapi *livepeerAPI.Client
+	lapi *api.Client
 	ipfs clients.IPFS
 	amqp event.AMQPClient
 }
@@ -197,7 +197,7 @@ func (r *runner) buildTaskContext(ctx context.Context, info data.TaskInfo) (*Tas
 	return &TaskContext{ctx, r, info, task, inputAsset, outputAsset, inputOS, outputOS}, nil
 }
 
-func (r *runner) getAssetAndOS(assetID string) (*livepeerAPI.Asset, drivers.OSSession, error) {
+func (r *runner) getAssetAndOS(assetID string) (*api.Asset, drivers.OSSession, error) {
 	if assetID == "" {
 		return nil, nil, nil
 	}

--- a/task/transcode.go
+++ b/task/transcode.go
@@ -215,7 +215,12 @@ out:
 	if err != nil && err != io.EOF {
 		return nil, err
 	}
-	outFiles[0].WriteTrailer()
+	for i, f := range outFiles {
+		if err := f.WriteTrailer(); err != nil {
+			glog.Errorf("Error writing trailer file=%d err=%v\n", i, err)
+			return nil, fmt.Errorf("error writing trailer of file %d: %w", i, err)
+		}
+	}
 	fullPath = videoFileName(outAsset.PlaybackID)
 	ws = outBuffers[0]
 	videoFilePath, err := tctx.outputOS.SaveData(ctx, fullPath, ws.Reader(), nil, fileUploadTimeout)

--- a/task/transcode.go
+++ b/task/transcode.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/golang/glog"
+	lp_api "github.com/livepeer/go-api-client"
 	"github.com/livepeer/go-livepeer/drivers"
 	"github.com/livepeer/joy4/av"
 	"github.com/livepeer/joy4/av/avutil"
@@ -139,8 +140,8 @@ func TaskTranscode(tctx *TaskContext) (*data.TaskOutput, error) {
 	}
 
 	streamName := fmt.Sprintf("vod_%s", time.Now().Format("2006-01-02T15:04:05Z07:00"))
-	profile := tctx.Params.Transcode.Profile
-	stream, err := lapi.CreateStreamEx(streamName, false, nil, profile)
+	profiles := []lp_api.Profile{tctx.Params.Transcode.Profile}
+	stream, err := lapi.CreateStream(lp_api.CreateStreamReq{Name: streamName, Profiles: profiles})
 	if err != nil {
 		return nil, err
 	}
@@ -181,7 +182,7 @@ out:
 		}
 		glog.V(model.VERBOSE).Infof("Got segment seqNo=%d pts=%s dur=%s data len bytes=%d\n", seg.SeqNo, seg.Pts, seg.Duration, len(seg.Data))
 		started := time.Now()
-		transcoded, err = lapi.PushSegment(stream.ID, seg.SeqNo, seg.Duration, seg.Data, contentResolution)
+		transcoded, err = lapi.PushSegmentR(stream.ID, seg.SeqNo, seg.Duration, seg.Data, contentResolution)
 		if err != nil {
 			glog.Errorf("Segment push playbackID=%s err=%v\n", inputPlaybackID, err)
 			break

--- a/task/transcode.go
+++ b/task/transcode.go
@@ -119,6 +119,7 @@ func fileWriter(size int64) WriteSeekCloser {
 func TaskTranscode(tctx *TaskContext) (*data.TaskOutput, error) {
 	var (
 		ctx             = tctx.Context
+		outAsset        = tctx.OutputAsset
 		inputPlaybackID = tctx.InputAsset.PlaybackID
 		lapi            = tctx.lapi
 	)
@@ -148,10 +149,10 @@ func TaskTranscode(tctx *TaskContext) (*data.TaskOutput, error) {
 	defer lapi.DeleteStream(stream.ID)
 
 	glog.V(model.DEBUG).Infof("Created vod stream id=%s name=%s\n", stream.ID, stream.Name)
-	gctx, gcancel := context.WithCancel(ctx)
-	defer gcancel()
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
 	segmentsIn := make(chan *model.HlsSegment)
-	if err = segmenter.StartSegmentingR(gctx, sourceFile, true, 0, 0, segLen, false, segmentsIn); err != nil {
+	if err = segmenter.StartSegmentingR(ctx, sourceFile, true, 0, 0, segLen, false, segmentsIn); err != nil {
 		return nil, err
 	}
 	var outFiles []av.Muxer
@@ -208,33 +209,31 @@ out:
 			}
 		}
 	}
-	if err == io.EOF {
-		err = nil
+	if ctxErr := ctx.Err(); err == nil && ctxErr != nil {
+		err = ctxErr
 	}
-	if err != nil {
+	if err != nil && err != io.EOF {
 		return nil, err
 	}
-	var videoFilePath string
 	outFiles[0].WriteTrailer()
-	asset := tctx.OutputAsset
-	fullPath = videoFileName(asset.PlaybackID)
+	fullPath = videoFileName(outAsset.PlaybackID)
 	ws = outBuffers[0]
-	videoFilePath, err = tctx.outputOS.SaveData(gctx, fullPath, ws.Reader(), nil, fileUploadTimeout)
+	videoFilePath, err := tctx.outputOS.SaveData(ctx, fullPath, ws.Reader(), nil, fileUploadTimeout)
 	if err != nil {
 		return nil, fmt.Errorf("error uploading file=%q to object store: %w", fullPath, err)
 	}
-	glog.Infof("Saved file with playbackID=%s to url=%s", asset.PlaybackID, videoFilePath)
+	glog.Infof("Saved file with playbackID=%s to url=%s", outAsset.PlaybackID, videoFilePath)
 
-	metadata, err := Probe(gctx, asset.Name+"_"+tctx.Params.Transcode.Profile.Name, NewReadCounter(ws.Reader()))
+	metadata, err := Probe(ctx, outAsset.Name+"_"+tctx.Params.Transcode.Profile.Name, NewReadCounter(ws.Reader()))
 	if err != nil {
 		return nil, err
 	}
-	metadataFilePath, err := saveMetadataFile(gctx, tctx.outputOS, asset.PlaybackID, metadata)
+	metadataFilePath, err := saveMetadataFile(ctx, tctx.outputOS, outAsset.PlaybackID, metadata)
 	if err != nil {
 		return nil, err
 	}
 	// RecordStream on output file for HLS playback
-	playbackRecordingId, err := Prepare(tctx, metadata.AssetSpec, ws.Reader())
+	playbackRecordingId, err := Prepare(tctx.WithContext(ctx), metadata.AssetSpec, ws.Reader())
 	if err != nil {
 		glog.Errorf("error preparing imported file assetId=%s err=%q", tctx.OutputAsset.ID, err)
 	}

--- a/task/transcode.go
+++ b/task/transcode.go
@@ -11,7 +11,7 @@ import (
 	"time"
 
 	"github.com/golang/glog"
-	lp_api "github.com/livepeer/go-api-client"
+	api "github.com/livepeer/go-api-client"
 	"github.com/livepeer/go-livepeer/drivers"
 	"github.com/livepeer/joy4/av"
 	"github.com/livepeer/joy4/av/avutil"
@@ -141,8 +141,8 @@ func TaskTranscode(tctx *TaskContext) (*data.TaskOutput, error) {
 	}
 
 	streamName := fmt.Sprintf("vod_%s", time.Now().Format("2006-01-02T15:04:05Z07:00"))
-	profiles := []lp_api.Profile{tctx.Params.Transcode.Profile}
-	stream, err := lapi.CreateStream(lp_api.CreateStreamReq{Name: streamName, Profiles: profiles})
+	profiles := []api.Profile{tctx.Params.Transcode.Profile}
+	stream, err := lapi.CreateStream(api.CreateStreamReq{Name: streamName, Profiles: profiles})
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This updates both stream-tester and go-api-client with the following fixes:
 - https://github.com/livepeer/stream-tester/pull/164
 - https://github.com/livepeer/go-api-client/pull/9
 - https://github.com/livepeer/go-api-client/pull/10

Upon fixing the usage of the libs, I also figured out that cancellation was not being
handled properly in the transcode and prepare tasks. Without https://github.com/livepeer/stream-tester/pull/164 
it actually wouldn't be fixable, since the segmenter didn't handle cancellation, but 
now it does!

~~So this also finally fixes NOT https://github.com/livepeer/task-runner/issues/19 !!~~
Actually figured out that this only fixes cancellation on transcode/prepare. There may
still be something wrong with the import logic :(