### PR TITLE
task/probe: Add log with ffprobe output (incl `start_time`)

### DIFF
--- a/task/import.go
+++ b/task/import.go
@@ -42,7 +42,7 @@ func TaskImport(tctx *TaskContext) (*data.TaskOutput, error) {
 	go ReportProgress(egCtx, tctx.lapi, tctx.Task.ID, size, mainReader.Count)
 	// Probe the source file to retrieve metadata
 	eg.Go(func() (err error) {
-		metadata, err = Probe(egCtx, filename, mainReader)
+		metadata, err = Probe(egCtx, tctx.OutputAsset.ID, filename, mainReader)
 		pipe.CloseWithError(err)
 		if err != nil {
 			return err

--- a/task/probe.go
+++ b/task/probe.go
@@ -16,9 +16,10 @@ import (
 )
 
 var (
-	supportedFormats     = []string{"mp4", "mov"}
-	supportedVideoCodecs = map[string]bool{"h264": true}
-	supportedAudioCodecs = map[string]bool{"aac": true}
+	supportedFormats      = []string{"mp4", "mov"}
+	supportedVideoCodecs  = map[string]bool{"h264": true}
+	supportedPixelFormats = map[string]bool{"yuv420p": true}
+	supportedAudioCodecs  = map[string]bool{"aac": true}
 )
 
 type FileMetadata struct {
@@ -123,10 +124,15 @@ func containsStr(slc []string, val string) bool {
 func toAssetTrack(stream *ffprobe.Stream) (*api.AssetTrack, error) {
 	if stream.CodecType != "video" && stream.CodecType != "audio" {
 		return nil, fmt.Errorf("unsupported codec type: %s", stream.CodecType)
-	} else if stream.CodecType == "video" && !supportedVideoCodecs[stream.CodecName] {
-		return nil, fmt.Errorf("unsupported video codec: %s", stream.CodecName)
 	} else if stream.CodecType == "audio" && !supportedAudioCodecs[stream.CodecName] {
 		return nil, fmt.Errorf("unsupported audio codec: %s", stream.CodecName)
+	} else if stream.CodecType == "video" {
+		if !supportedVideoCodecs[stream.CodecName] {
+			return nil, fmt.Errorf("unsupported video codec: %s", stream.CodecName)
+		}
+		if !supportedPixelFormats[stream.PixFmt] {
+			return nil, fmt.Errorf("unsupported video pixel format: %s", stream.PixFmt)
+		}
 	}
 
 	startTime, err := strconv.ParseFloat(stream.StartTime, 64)

--- a/task/probe.go
+++ b/task/probe.go
@@ -208,7 +208,7 @@ func logProbeData(assetId, filename string, probeData *ffprobe.ProbeData) {
 	var maxStartTime float64
 	for _, stream := range probeData.Streams {
 		add := func(field string, value string) {
-			streamFields = append(streamFields, fmt.Sprintf("stream_%d_%s=%s, ", stream.Index, field, value))
+			streamFields = append(streamFields, fmt.Sprintf("stream_%d_%s=%q", stream.Index, field, value))
 		}
 		add("type", stream.CodecType)
 		add("codec", stream.CodecName)

--- a/task/transcode.go
+++ b/task/transcode.go
@@ -229,7 +229,7 @@ out:
 	}
 	glog.Infof("Saved file with playbackID=%s to url=%s", outAsset.PlaybackID, videoFilePath)
 
-	metadata, err := Probe(ctx, outAsset.Name+"_"+tctx.Params.Transcode.Profile.Name, NewReadCounter(ws.Reader()))
+	metadata, err := Probe(ctx, outAsset.ID, outAsset.Name+"_"+tctx.Params.Transcode.Profile.Name, NewReadCounter(ws.Reader()))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
We need this in order to create a better sense of the kind of files that people upload to our API.

We can assume that the start_time bug is not very frequent, but we don't really know until we have this.

After having this, should also create some dashboards and/or alerts to know if too many files with
a big start_time are bing uploaded to the VOD API.

This implements #42 