### PR TITLE
task/import: Use original HLS recording for assets playback URL

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.16
 
 require (
 	github.com/golang/glog v1.0.0
-	github.com/livepeer/go-api-client v0.2.2-0.20220614232202-3f52abca6d18
+	github.com/livepeer/go-api-client v0.2.2
 	github.com/livepeer/go-livepeer v0.5.31
 	github.com/livepeer/joy4 v0.1.2-0.20220210094601-95e4d28f5f07
 	github.com/livepeer/livepeer-data v0.4.14

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.16
 
 require (
 	github.com/golang/glog v1.0.0
-	github.com/livepeer/go-api-client v0.2.1
+	github.com/livepeer/go-api-client v0.2.2-0.20220614232202-3f52abca6d18
 	github.com/livepeer/go-livepeer v0.5.31
 	github.com/livepeer/joy4 v0.1.2-0.20220210094601-95e4d28f5f07
 	github.com/livepeer/livepeer-data v0.4.14

--- a/go.sum
+++ b/go.sum
@@ -693,8 +693,8 @@ github.com/labstack/gommon v0.3.0/go.mod h1:MULnywXg0yavhxWKc+lOruYdAhDwPK9wf0OL
 github.com/leanovate/gopter v0.2.9/go.mod h1:U2L/78B+KVFIx2VmW6onHJQzXtFb+p5y3y2Sh+Jxxv8=
 github.com/lib/pq v1.0.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
 github.com/lib/pq v1.8.0/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
-github.com/livepeer/go-api-client v0.2.2-0.20220614232202-3f52abca6d18 h1:X6+jLJcn87rdlW71dN+PVdtQGGQvbPYc2qpm0FTxN40=
-github.com/livepeer/go-api-client v0.2.2-0.20220614232202-3f52abca6d18/go.mod h1:FPgo6hPAEQkWS/Bmepdm+O/LWfurbmym93ghzLueTUo=
+github.com/livepeer/go-api-client v0.2.2 h1:Uy6DAO5cLjeg/kKIzaHD1t7BxIgwBt16K3CtAUflVNA=
+github.com/livepeer/go-api-client v0.2.2/go.mod h1:FPgo6hPAEQkWS/Bmepdm+O/LWfurbmym93ghzLueTUo=
 github.com/livepeer/go-livepeer v0.5.31 h1:LcN+qDnqWRws7fdVYc4ucZPVcLQRs2tehUYCQVnlnRw=
 github.com/livepeer/go-livepeer v0.5.31/go.mod h1:cpBikcGWApkx0cyR0Ht+uAym7j3uAwXGpPbvaOA8XUU=
 github.com/livepeer/joy4 v0.1.2-0.20191121080656-b2fea45cbded/go.mod h1:xkDdm+akniYxVT9KW1Y2Y7Hso6aW+rZObz3nrA9yTHw=

--- a/go.sum
+++ b/go.sum
@@ -693,8 +693,8 @@ github.com/labstack/gommon v0.3.0/go.mod h1:MULnywXg0yavhxWKc+lOruYdAhDwPK9wf0OL
 github.com/leanovate/gopter v0.2.9/go.mod h1:U2L/78B+KVFIx2VmW6onHJQzXtFb+p5y3y2Sh+Jxxv8=
 github.com/lib/pq v1.0.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
 github.com/lib/pq v1.8.0/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
-github.com/livepeer/go-api-client v0.2.1 h1:u8CfamDQzLETeFAEUpKPeZFOaMGz6q7AU/Fpp2HErT0=
-github.com/livepeer/go-api-client v0.2.1/go.mod h1:FPgo6hPAEQkWS/Bmepdm+O/LWfurbmym93ghzLueTUo=
+github.com/livepeer/go-api-client v0.2.2-0.20220614232202-3f52abca6d18 h1:X6+jLJcn87rdlW71dN+PVdtQGGQvbPYc2qpm0FTxN40=
+github.com/livepeer/go-api-client v0.2.2-0.20220614232202-3f52abca6d18/go.mod h1:FPgo6hPAEQkWS/Bmepdm+O/LWfurbmym93ghzLueTUo=
 github.com/livepeer/go-livepeer v0.5.31 h1:LcN+qDnqWRws7fdVYc4ucZPVcLQRs2tehUYCQVnlnRw=
 github.com/livepeer/go-livepeer v0.5.31/go.mod h1:cpBikcGWApkx0cyR0Ht+uAym7j3uAwXGpPbvaOA8XUU=
 github.com/livepeer/joy4 v0.1.2-0.20191121080656-b2fea45cbded/go.mod h1:xkDdm+akniYxVT9KW1Y2Y7Hso6aW+rZObz3nrA9yTHw=

--- a/task/import.go
+++ b/task/import.go
@@ -9,7 +9,6 @@ import (
 	"mime"
 	"net/http"
 	"path"
-	"strings"
 
 	"github.com/golang/glog"
 	api "github.com/livepeer/go-api-client"
@@ -60,17 +59,12 @@ func TaskImport(tctx *TaskContext) (*data.TaskOutput, error) {
 		glog.Infof("Saved file=%s to url=%s", fullPath, videoFilePath)
 		return nil
 	})
-	// Wait for async goroutines finish to run prepare
 	if err := eg.Wait(); err != nil {
 		// TODO: Delete the source file
 		return nil, err
 	}
-	playbackRecordingId := ""
-	isInputRecording := strings.HasPrefix(params.URL, "https://livepeercdn.") && strings.Contains(params.URL, "/recordings/")
-	// Temporarily skip preparing recorded streams while we figure out a bug in the orchestrators latest version.
-	// TODO: Remove this check and prepare all assets.
-	if !isInputRecording {
-		// Download our imported output file
+	playbackRecordingId := params.RecordedSessionID
+	if playbackRecordingId == "" {
 		fileInfoReader, err := osSess.ReadData(ctx, fullPath)
 		if err != nil {
 			return nil, fmt.Errorf("error reading imported file from output OS path=%s err=%w", fullPath, err)


### PR DESCRIPTION
For assets created from a livestream recording, we have been skipping the prepare step because of 
an apparent bug in `go-livepeer` that caused them not to be processed properly (`Invalid argument`).

The ideal flow for this though would actually be to avoid re-transcoding these recordings when we are
creating the assets. We have already created an HLS playlist for the livestream when it was recorded
in the first place. So we can just use that for the resulting asset playback as well.