### PR TITLE
task/probe: Fix some remaining bugs in probe

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ COPY . .
 
 RUN make "version=$version"
 
-FROM debian:stretch-slim
+FROM debian:buster-slim
 
 RUN apt update \
   && apt install -y ffmpeg ca-certificates \

--- a/task/import.go
+++ b/task/import.go
@@ -69,7 +69,7 @@ func TaskImport(tctx *TaskContext) (*data.TaskOutput, error) {
 	cancelProgress()
 	playbackRecordingID, err := prepareImportedAsset(tctx, metadata, fullPath)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("error preparing asset: %w", err)
 	}
 	assetSpec := *metadata.AssetSpec
 	assetSpec.PlaybackRecordingID = playbackRecordingID
@@ -137,7 +137,7 @@ func prepareImportedAsset(tctx *TaskContext, metadata *FileMetadata, fullPath st
 
 	playbackRecordingID, err := Prepare(tctx, metadata.AssetSpec, importedFile, 0.5)
 	if err != nil {
-		glog.Errorf("error preparing imported file assetId=%s err=%q", tctx.OutputAsset.ID, err)
+		glog.Errorf("Error preparing file assetId=%s taskType=import err=%q", tctx.OutputAsset.ID, err)
 		return "", err
 	}
 	return playbackRecordingID, nil

--- a/task/probe.go
+++ b/task/probe.go
@@ -18,7 +18,7 @@ import (
 var (
 	supportedFormats      = []string{"mp4", "mov"}
 	supportedVideoCodecs  = map[string]bool{"h264": true}
-	supportedPixelFormats = map[string]bool{"yuv420p": true}
+	supportedPixelFormats = map[string]bool{"yuv420p": true, "yuvj420p": true}
 	supportedAudioCodecs  = map[string]bool{"aac": true}
 )
 

--- a/task/transcode.go
+++ b/task/transcode.go
@@ -260,11 +260,10 @@ out:
 		return nil, err
 	}
 	cancelProgress()
-	// RecordStream on output file for HLS playback
 	playbackRecordingId, err := Prepare(tctx.WithContext(ctx), metadata.AssetSpec, ws.Reader(), 0.5)
 	if err != nil {
-		glog.Errorf("error preparing imported file assetId=%s err=%q", tctx.OutputAsset.ID, err)
-		return nil, err
+		glog.Errorf("Error preparing file assetId=%s taskType=transcode err=%q", tctx.OutputAsset.ID, err)
+		return nil, fmt.Errorf("error preparing asset: %w", err)
 	}
 	assetSpec := *metadata.AssetSpec
 	assetSpec.PlaybackRecordingID = playbackRecordingId


### PR DESCRIPTION
 - List of supported pixel formats is incomplete
 - We are using a really really old version of ffmpeg (major 3) which doesn't even detect the pix format sometimes. Buster bumps it at least to major 4.
 - Improve some error messages