### PR TITLE
probe: Ignore data tracks in assets

### DIFF
--- a/task/probe.go
+++ b/task/probe.go
@@ -83,6 +83,8 @@ func toAssetSpec(filename string, probeData *ffprobe.ProbeData, size uint64, has
 		track, err := toAssetTrack(stream)
 		if err != nil {
 			return nil, err
+		} else if track == nil {
+			continue
 		}
 		if track.Type == "video" {
 			if hasVideo {
@@ -122,7 +124,9 @@ func containsStr(slc []string, val string) bool {
 }
 
 func toAssetTrack(stream *ffprobe.Stream) (*api.AssetTrack, error) {
-	if stream.CodecType != "video" && stream.CodecType != "audio" {
+	if stream.CodecType == "data" {
+		return nil, nil
+	} else if stream.CodecType != "video" && stream.CodecType != "audio" {
 		return nil, fmt.Errorf("unsupported codec type: %s", stream.CodecType)
 	} else if stream.CodecType == "audio" && !supportedAudioCodecs[stream.CodecName] {
 		return nil, fmt.Errorf("unsupported audio codec: %s", stream.CodecName)


### PR DESCRIPTION
This is to merely ignore any `data` tracks present in tasks in order to not have them fail processing because of that.

We will likely be just ignoring those, and thus not having the subtitles in the resulting HLS renditions, but that's
still better than just failing the processing altogether and not importing the asset properly to the VOD API.

Also considered still keeping information about the data track in the asset, but preferred not to while we don't
have any real handling of those, just ignore them. Let's not commit to any interfaces about how that's gonna look
in the future.

This fixes livepeer/studio#1157