### PR TITLE
task/import: Revert the early optimization

### DIFF
--- a/task/import.go
+++ b/task/import.go
@@ -38,7 +38,7 @@ func TaskImport(tctx *TaskContext) (*data.TaskOutput, error) {
 		var progressCtx context.Context
 		progressCtx, cancelProgress = context.WithCancel(ctx)
 		counter := NewReadCounter(r)
-		go ReportProgress(progressCtx, tctx.lapi, tctx.Task.ID, size, counter.Count, 0, 0.1)
+		go ReportProgress(progressCtx, tctx.lapi, tctx.Task.ID, size, counter.Count, from, to)
 		return counter
 	}
 


### PR DESCRIPTION
The error group and piped streams were causing more
harm than good. Let's simplify the code and see if
some of the weirder errors stop happening (like the
weird 1 status codes from ffprobe, or the tasks
disappearing and restarting in another node)