### PR TITLE
task/upload: Create healthcheck to track catalyst tasks

### DIFF
--- a/task/runner.go
+++ b/task/runner.go
@@ -256,6 +256,13 @@ func (r *runner) HandleCatalysis(ctx context.Context, taskId, nextStep string, c
 	task, err := r.lapi.GetTask(taskId)
 	if err != nil {
 		return fmt.Errorf("failed to get task %s: %w", taskId, err)
+	} else if task.Status.Phase != "running" {
+		return fmt.Errorf("task %s is not running", taskId)
+	}
+	progress := 0.95 * callback.CompletionRatio
+	err = r.lapi.UpdateTaskStatus(task.ID, "running", progress)
+	if err != nil {
+		glog.Warningf("Failed to update task progress. taskID=%s err=%v", task.ID, err)
 	}
 	if callback.Status == "error" {
 		err := fmt.Errorf("got catalyst error: %s", callback.Error)
@@ -265,11 +272,6 @@ func (r *runner) HandleCatalysis(ctx context.Context, taskId, nextStep string, c
 		return r.publishTaskResult(ctx, taskId, nil, err)
 	} else if callback.Status == "completed" {
 		return r.scheduleTaskStep(ctx, taskId, nextStep, callback)
-	}
-	progress := 0.95 * callback.CompletionRatio
-	err = r.lapi.UpdateTaskStatus(task.ID, "running", progress)
-	if err != nil {
-		return fmt.Errorf("failed to update task %s status: %w", taskId, err)
 	}
 	return nil
 }

--- a/task/upload.go
+++ b/task/upload.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/url"
 	"path"
+	"time"
 
 	"github.com/livepeer/go-api-client"
 	"github.com/livepeer/livepeer-data/pkg/data"
@@ -48,6 +49,24 @@ func TaskUpload(tctx *TaskContext) (*data.TaskOutput, error) {
 		}
 		if err := tctx.catalyst.UploadVOD(ctx, uploadReq); err != nil {
 			return nil, fmt.Errorf("failed to call catalyst: %v", err)
+		}
+		err = tctx.delayTaskStep(ctx, tctx.Task.ID, "checkCatalyst", nil)
+		if err != nil {
+			return nil, fmt.Errorf("failed scheduling catalyst healthcheck: %v", err)
+		}
+		return nil, nil
+	case "checkCatalyst":
+		task := tctx.Task
+		if task.Status.Phase != "running" {
+			return nil, nil
+		}
+		updatedAt := data.NewUnixMillisTime(task.Status.UpdatedAt)
+		if updateAge := time.Since(updatedAt.Time); updateAge > time.Minute {
+			return nil, fmt.Errorf("cataylist task lost (last update %s ago)", updateAge)
+		}
+		err := tctx.delayTaskStep(ctx, task.ID, "checkCatalyst", nil)
+		if err != nil {
+			return nil, fmt.Errorf("failed to schedule next check: %v", err)
 		}
 		return nil, nil
 	case "finalize":

--- a/task/upload.go
+++ b/task/upload.go
@@ -62,7 +62,7 @@ func TaskUpload(tctx *TaskContext) (*data.TaskOutput, error) {
 		}
 		updatedAt := data.NewUnixMillisTime(task.Status.UpdatedAt)
 		if updateAge := time.Since(updatedAt.Time); updateAge > time.Minute {
-			return nil, fmt.Errorf("cataylist task lost (last update %s ago)", updateAge)
+			return nil, fmt.Errorf("catalyst task lost (last update %s ago)", updateAge)
 		}
 		err := tctx.delayTaskStep(ctx, task.ID, "checkCatalyst", nil)
 		if err != nil {


### PR DESCRIPTION
This creates a way of delaying "task step schedule" events in order to implement a recurring healthcheck
on the catalyst tasks. This means that while Catalyst is executing on some task, the `task-runner` will be 
periodically (every minute) checking if it has received at least a progress callback from Catalyst. If it hasn't
received anything in over a minute, it will consider the Catalyst job to be lost and fail the task on the Studio side.

This implements #51 