### PR TITLE
runner: add basic replace of error text messages

### DIFF
--- a/task/runner.go
+++ b/task/runner.go
@@ -270,10 +270,10 @@ func humanizeError(err error) error {
 
 	if strings.Contains(errMsg, "unexpected eof") {
 		return errors.New("file download failed")
-	} else if strings.Contains(errMsg, "multipartUpload: upload multipart failed") {
+	} else if strings.Contains(errMsg, "multipartupload: upload multipart failed") {
 		return errors.New("internal error saving file to storage")
 	} else if strings.Contains(errMsg, "mp4io: parse error") {
-		return UnretriableError{errors.New("file format unsupported, must be MP4")}
+		return UnretriableError{errors.New("file format unsupported, must be a valid MP4")}
 	}
 
 	isProcessing := strings.Contains(errMsg, "error running ffprobe [] exit status 1") ||
@@ -283,6 +283,14 @@ func humanizeError(err error) error {
 
 	if isProcessing {
 		return errors.New("internal error processing file")
+	}
+
+	isTimeout := strings.Contains(errMsg, "context deadline exceeded") ||
+		strings.Contains(errMsg, "context canceled") ||
+		strings.Contains(errMsg, "context deadline exceeded")
+
+	if isTimeout {
+		return errors.New("execution timeout")
 	}
 
 	return err

--- a/task/runner.go
+++ b/task/runner.go
@@ -222,20 +222,7 @@ func (r *runner) getAssetAndOS(assetID string) (*api.Asset, drivers.OSSession, e
 func (r *runner) publishTaskResult(ctx context.Context, task data.TaskInfo, output *data.TaskOutput, err error) error {
 	resultCh := make(chan event.PublishResult, 1)
 
-	if err != nil {
-		if strings.Contains(err.Error(), "unexpected EOF") {
-			err = errors.New("file download failed")
-		} else if strings.Contains(err.Error(), "error running ffprobe [] exit status 1") ||
-			strings.Contains(err.Error(), "Could not create stream ID") ||
-			strings.Contains(err.Error(), "502 Bad Gateway") ||
-			(strings.Contains(err.Error(), "EOF") && strings.Contains(err.Error(), "error processing file")) {
-			err = errors.New("error processing file")
-		} else if strings.Contains(err.Error(), "MultipartUpload: upload multipart failed") {
-			err = errors.New("error saving file to internal storage")
-		} else if strings.Contains(err.Error(), "mp4io: parse error") {
-			err = errors.New("file format unsupported, must be MP4")
-		}
-	}
+	err = humanizeError(err)
 
 	msg := event.AMQPMessage{
 		Exchange:   r.ExchangeName,
@@ -272,6 +259,33 @@ func errorInfo(err error) *data.ErrorInfo {
 		return nil
 	}
 	return &data.ErrorInfo{Message: err.Error(), Unretriable: IsUnretriable(err)}
+}
+
+func humanizeError(err error) error {
+	if err == nil {
+		return nil
+	}
+
+	errMsg := strings.ToLower(err.Error())
+
+	if strings.Contains(errMsg, "unexpected eof") {
+		return errors.New("file download failed")
+	} else if strings.Contains(errMsg, "multipartUpload: upload multipart failed") {
+		return errors.New("internal error saving file to storage")
+	} else if strings.Contains(errMsg, "mp4io: parse error") {
+		return UnretriableError{errors.New("file format unsupported, must be MP4")}
+	}
+
+	isProcessing := strings.Contains(errMsg, "error running ffprobe [] exit status 1") ||
+		strings.Contains(errMsg, "could not create stream id") ||
+		strings.Contains(errMsg, "502 bad gateway") ||
+		(strings.Contains(errMsg, "eof") && strings.Contains(errMsg, "error processing file"))
+
+	if isProcessing {
+		return errors.New("internal error processing file")
+	}
+
+	return err
 }
 
 func blockUntil(t <-chan time.Time) { <-t }


### PR DESCRIPTION
Add a basic replace of error messages with more clear messages sent to Studio.
Fixes [1162](https://github.com/livepeer/studio/issues/1162)  