### PR TITLE
task/probe: Add an explicit error for lack of audio in input

### DIFF
--- a/task/probe.go
+++ b/task/probe.go
@@ -78,7 +78,7 @@ func toAssetSpec(filename string, probeData *ffprobe.ProbeData, size uint64, has
 			Tracks:      make([]*api.AssetTrack, 0, len(probeData.Streams)),
 		},
 	}
-	var hasVideo bool
+	var hasVideo, hasAudio bool
 	for _, stream := range probeData.Streams {
 		track, err := toAssetTrack(stream)
 		if err != nil {
@@ -92,10 +92,14 @@ func toAssetSpec(filename string, probeData *ffprobe.ProbeData, size uint64, has
 			}
 			hasVideo = true
 		}
+		hasAudio = hasAudio || track.Type == "audio"
 		spec.VideoSpec.Tracks = append(spec.VideoSpec.Tracks, track)
 	}
 	if !hasVideo {
 		return nil, fmt.Errorf("no video track found in file")
+	}
+	if !hasAudio {
+		return nil, fmt.Errorf("no audio track found in file")
 	}
 	return spec, nil
 }


### PR DESCRIPTION
The m3u8 tester that we use does not support anything else than 1 video and 1 audio track.

We will be able to get rid of it once we migrate to the Catalyst VOD pipeline, since we will be
able to rely on the generated playlists being good (sth we can't do on the current 
go-livepeer-recording's based pipeline).

So this is a temp solution until Catalyst, just to have an explicit error to users.