### PR TITLE
task: Support ipfs:// URI imports

### DIFF
--- a/cmd/task-runner/task-runner.go
+++ b/cmd/task-runner/task-runner.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/signal"
 	"strconv"
+	"strings"
 	"syscall"
 	"time"
 
@@ -53,6 +54,15 @@ func URLVarFlag(fs *flag.FlagSet, dest **url.URL, name, value, usage string) {
 	})
 }
 
+func StringsVarFlag(fs *flag.FlagSet, dest *[]string, name, value, usage string) {
+	*dest = strings.Split(value, ",")
+
+	fs.Func(name, usage, func(s string) error {
+		*dest = strings.Split(s, ",")
+		return nil
+	})
+}
+
 func parseFlags(build BuildFlags) cliFlags {
 	cli := cliFlags{}
 	fs := flag.NewFlagSet("livepeer-task-runner", flag.ExitOnError)
@@ -71,6 +81,7 @@ func parseFlags(build BuildFlags) cliFlags {
 	fs.StringVar(&cli.runnerOpts.PinataAccessToken, "pinata-access-token", "", "JWT access token for the Piñata API")
 	URLVarFlag(fs, &cli.runnerOpts.PlayerImmutableURL, "player-immutable-url", "ipfs://bafybeihcqgu4rmsrlkqvavkzsnu7h5n66jopckes6u5zrhs3kcffqvylge/", "Base URL for an immutable version of the Livepeer Player to be included in NFTs metadata")
 	URLVarFlag(fs, &cli.runnerOpts.PlayerExternalURL, "player-external-url", "https://lvpr.tv/", "Base URL for the updateable version of the Livepeer Player to be included in NFTs external URL")
+	StringsVarFlag(fs, &cli.runnerOpts.ImportIPFSGatewayURLs, "import-ipfs-gateway-urls", "Comma delimited ordered list of IPFS gateways (includes /ipfs/ suffix) to import assets from", "https://w3s.link/ipfs/,https://ipfs.io/ipfs/,https://cloudflare-ipfs.com/ipfs/")
 
 	// Server options
 	fs.StringVar(&cli.serverOpts.Host, "host", "localhost", "Hostname to bind to")

--- a/task/import.go
+++ b/task/import.go
@@ -17,6 +17,8 @@ import (
 	"github.com/livepeer/livepeer-data/pkg/data"
 )
 
+const IPFS_PREFIX = "ipfs://"
+
 type ImportTaskConfig struct {
 	// Ordered list of IPFS gateways (includes /ipfs/ suffix) to import assets from
 	ImportIPFSGatewayURLs []string
@@ -116,9 +118,8 @@ func getFile(ctx context.Context, osSess drivers.OSSession, cfg ImportTaskConfig
 		return "", 0, nil, fmt.Errorf("no import URL or direct upload object key: %+v", params)
 	}
 
-	ipfsPrefix := "ipfs://"
-	if strings.HasPrefix(params.URL, ipfsPrefix) {
-		cid := strings.TrimPrefix(params.URL, ipfsPrefix)
+	if strings.HasPrefix(params.URL, IPFS_PREFIX) {
+		cid := strings.TrimPrefix(params.URL, IPFS_PREFIX)
 		return getFileIPFS(ctx, cfg.ImportIPFSGatewayURLs, cid)
 	}
 

--- a/task/import.go
+++ b/task/import.go
@@ -9,12 +9,18 @@ import (
 	"mime"
 	"net/http"
 	"path"
+	"strings"
 
 	"github.com/golang/glog"
 	api "github.com/livepeer/go-api-client"
 	"github.com/livepeer/go-tools/drivers"
 	"github.com/livepeer/livepeer-data/pkg/data"
 )
+
+type ImportTaskConfig struct {
+	// Ordered list of IPFS gateways (includes /ipfs/ suffix) to import assets from
+	ImportIPFSGatewayURLs []string
+}
 
 func TaskImport(tctx *TaskContext) (*data.TaskOutput, error) {
 	var (
@@ -24,7 +30,7 @@ func TaskImport(tctx *TaskContext) (*data.TaskOutput, error) {
 		osSess         = tctx.outputOS // Import deals with outputOS only (URL -> ObjectStorage)
 		cancelProgress context.CancelFunc
 	)
-	filename, size, contents, err := getFile(ctx, osSess, params)
+	filename, size, contents, err := getFile(ctx, osSess, tctx.ImportTaskConfig, params)
 	if err != nil {
 		return nil, err
 	}
@@ -93,7 +99,7 @@ func TaskImport(tctx *TaskContext) (*data.TaskOutput, error) {
 	}}, nil
 }
 
-func getFile(ctx context.Context, osSess drivers.OSSession, params api.UploadTaskParams) (name string, size uint64, content io.ReadCloser, err error) {
+func getFile(ctx context.Context, osSess drivers.OSSession, cfg ImportTaskConfig, params api.UploadTaskParams) (name string, size uint64, content io.ReadCloser, err error) {
 	if upedObjKey := params.UploadedObjectKey; upedObjKey != "" {
 		// TODO: We should simply "move" the file in case of direct import since we
 		// know the file is already in the object store. Independently, we also have
@@ -110,7 +116,36 @@ func getFile(ctx context.Context, osSess drivers.OSSession, params api.UploadTas
 		return "", 0, nil, fmt.Errorf("no import URL or direct upload object key: %+v", params)
 	}
 
-	req, err := http.NewRequestWithContext(ctx, "GET", params.URL, nil)
+	ipfsPrefix := "ipfs://"
+	if strings.HasPrefix(params.URL, ipfsPrefix) {
+		cid := strings.TrimPrefix(params.URL, ipfsPrefix)
+		return getFileIPFS(ctx, cfg.ImportIPFSGatewayURLs, cid)
+	}
+
+	// TODO: Implement Arweave support
+	// arPrefix := "ar://"
+	// if strings.HasPrefix(params.URL, arPrefix) {
+	// 	txID := strings.TrimPrefix(params.URL, arPrefix)
+	// 	return getFileArweave(ctx, txID)
+	// }
+
+	return getFileWithUrl(ctx, params.URL)
+}
+
+func getFileIPFS(ctx context.Context, gateways []string, cid string) (name string, size uint64, content io.ReadCloser, err error) {
+	for _, gateway := range gateways {
+		name, size, content, err = getFileWithUrl(ctx, gateway+cid)
+		if err == nil {
+			return name, size, content, nil
+		}
+		glog.Infof("Failed to get file from IPFS cid=%v url=%v err=%v", cid, gateway, err)
+	}
+
+	return "", 0, nil, err
+}
+
+func getFileWithUrl(ctx context.Context, url string) (name string, size uint64, content io.ReadCloser, err error) {
+	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
 	if err != nil {
 		return "", 0, nil, UnretriableError{fmt.Errorf("error creating http request: %w", err)}
 	}

--- a/task/runner.go
+++ b/task/runner.go
@@ -64,6 +64,7 @@ type RunnerOptions struct {
 	LivepeerAPIOptions      api.ClientOptions
 	Catalyst                *clients.CatalystOptions
 	ExportTaskConfig
+	ImportTaskConfig
 
 	TaskHandlers map[string]TaskHandler
 }


### PR DESCRIPTION
This PR adds support for importing ipfs:// URLs by extracting the CID and trying to import the asset from a list of configured trusted gateways. The runner will try the next gateway in the list if the previous one did not successfully return the asset.