### PR TITLE
task/import: Allow IPFS gateway URLs to contain query-strngs

### DIFF
--- a/task/import.go
+++ b/task/import.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"mime"
 	"net/http"
+	"net/url"
 	"path"
 	"strings"
 
@@ -137,7 +138,13 @@ func getFile(ctx context.Context, osSess drivers.OSSession, cfg ImportTaskConfig
 
 func getFileIPFS(ctx context.Context, gateways []string, cid string) (name string, size uint64, content io.ReadCloser, err error) {
 	for _, gateway := range gateways {
-		name, size, content, err = getFileWithUrl(ctx, gateway+cid)
+		url, err := url.Parse(gateway)
+		if err != nil {
+			glog.Errorf("error parsing gateway url=%q err=%q", gateway, err)
+			continue
+		}
+		url = url.JoinPath(cid)
+		name, size, content, err = getFileWithUrl(ctx, url.String())
 		if err == nil {
 			return name, size, content, nil
 		}

--- a/task/import.go
+++ b/task/import.go
@@ -23,7 +23,7 @@ const ARWEAVE_PREFIX = "ar://"
 
 type ImportTaskConfig struct {
 	// Ordered list of IPFS gateways (includes /ipfs/ suffix) to import assets from
-	ImportIPFSGatewayURLs []string
+	ImportIPFSGatewayURLs []*url.URL
 }
 
 func TaskImport(tctx *TaskContext) (*data.TaskOutput, error) {
@@ -136,15 +136,10 @@ func getFile(ctx context.Context, osSess drivers.OSSession, cfg ImportTaskConfig
 	return getFileWithUrl(ctx, params.URL)
 }
 
-func getFileIPFS(ctx context.Context, gateways []string, cid string) (name string, size uint64, content io.ReadCloser, err error) {
+func getFileIPFS(ctx context.Context, gateways []*url.URL, cid string) (name string, size uint64, content io.ReadCloser, err error) {
 	for _, gateway := range gateways {
-		url, err := url.Parse(gateway)
-		if err != nil {
-			glog.Errorf("error parsing gateway url=%q err=%q", gateway, err)
-			continue
-		}
-		url = url.JoinPath(cid)
-		name, size, content, err = getFileWithUrl(ctx, url.String())
+		url := gateway.JoinPath(cid).String()
+		name, size, content, err = getFileWithUrl(ctx, url)
 		if err == nil {
 			return name, size, content, nil
 		}


### PR DESCRIPTION
This is necessary to be able to use the Piñata dedicated gateway, since on their
new API we need to provide an access token in the request to be able to access
any file on IPFS network. This access token must be either in the query string
or in the headers, and so it's much easier to add support for query string for us.