### PR TITLE
task/export: Make 'file' the default NFT metadata

### DIFF
--- a/task/export.go
+++ b/task/export.go
@@ -155,18 +155,15 @@ func nftMetadata(asset *api.Asset, videoCID string, template api.NFTMetadataTemp
 			"description":   fmt.Sprintf("Livepeer video from asset %q", asset.Name),
 			"image":         livepeerLogoUrl,
 			"animation_url": videoUrl,
-			"properties": map[string]interface{}{
-				"video": videoUrl,
-			},
 		}
 	case api.NFTMetadataTemplatePlayer:
 		return map[string]interface{}{
 			"name":          asset.Name,
 			"description":   fmt.Sprintf("Livepeer video from asset %q", asset.Name),
 			"image":         livepeerLogoUrl,
-			"animation_url": buildPlayerUrl(config.PlayerImmutableURL, asset.PlaybackID, true),
-			"external_url":  buildPlayerUrl(config.PlayerExternalURL, asset.PlaybackID, false),
-			// TODO: Consider migrating these to `attributes` instead.
+			"animation_url": buildPlayerUrl(config.PlayerImmutableURL, videoCID, true),
+			"external_url":  buildPlayerUrl(config.PlayerExternalURL, videoCID, false),
+			// TODO: Consider migrating these to `attributes` instead. ref: https://github.com/livepeer/task-runner/pull/82#discussion_r1013538456
 			"properties": map[string]interface{}{
 				"video":                   videoUrl,
 				"com.livepeer.playbackId": asset.PlaybackID,

--- a/task/export.go
+++ b/task/export.go
@@ -152,6 +152,16 @@ func nftMetadata(asset *api.Asset, videoCID string, template api.NFTMetadataTemp
 	switch template {
 	default:
 		fallthrough
+	case api.NFTMetadataTemplateFile:
+		return map[string]interface{}{
+			"name":          asset.Name,
+			"description":   fmt.Sprintf("Livepeer video from asset %q", asset.Name),
+			"image":         livepeerLogoUrl,
+			"animation_url": videoUrl,
+			"properties": map[string]interface{}{
+				"video": videoUrl,
+			},
+		}
 	case api.NFTMetadataTemplatePlayer:
 		return map[string]interface{}{
 			"name":          asset.Name,
@@ -163,16 +173,6 @@ func nftMetadata(asset *api.Asset, videoCID string, template api.NFTMetadataTemp
 			"properties": map[string]interface{}{
 				"video":                   videoUrl,
 				"com.livepeer.playbackId": asset.PlaybackID,
-			},
-		}
-	case api.NFTMetadataTemplateFile:
-		return map[string]interface{}{
-			"name":          asset.Name,
-			"description":   fmt.Sprintf("Livepeer video from asset %q", asset.Name),
-			"image":         livepeerLogoUrl,
-			"animation_url": videoUrl,
-			"properties": map[string]interface{}{
-				"video": videoUrl,
 			},
 		}
 	}

--- a/task/export.go
+++ b/task/export.go
@@ -126,10 +126,7 @@ func saveNFTMetadata(ctx context.Context, ipfs clients.IPFS,
 		return "", fmt.Errorf("cannot create player NFT for asset without playback URL")
 	}
 	if template == "" {
-		template = api.NFTMetadataTemplatePlayer
-		if asset.PlaybackRecordingID == "" {
-			template = api.NFTMetadataTemplateFile
-		}
+		template = api.NFTMetadataTemplateFile
 	}
 	nftMetadata := nftMetadata(asset, videoCID, template, config)
 	mergeJson(nftMetadata, overrides)


### PR DESCRIPTION
It is more aligned with our new NFT and dStorage support strategy.

[moar ctx](https://discord.com/channels/423160867534929930/1009165020837466203/1037821695668531202) 