### PR TITLE
task: Fix catalyst callback handling logic to avoid spill overs

### DIFF
--- a/api/handler.go
+++ b/api/handler.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"net/http"
-	"strconv"
 	"time"
 
 	"github.com/golang/glog"
@@ -64,19 +63,12 @@ func (h *apiHandler) healthcheck(rw http.ResponseWriter, r *http.Request) {
 func (h *apiHandler) catalystHook(rw http.ResponseWriter, r *http.Request) {
 	taskId := httprouter.ParamsFromContext(r.Context()).ByName("id")
 	nextStep := r.URL.Query().Get("nextStep")
-	attemptIDStr := r.URL.Query().Get("attemptId")
+	attemptID := r.URL.Query().Get("attemptId")
 
 	var payload *clients.CatalystCallback
 	if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
 		respondError(r, rw, http.StatusBadRequest, err)
 		return
-	}
-	var attemptID *int
-	if attemptIDStr != "" {
-		id, err := strconv.Atoi(attemptIDStr)
-		if err == nil {
-			attemptID = &id
-		}
 	}
 
 	err := h.runner.HandleCatalysis(r.Context(), taskId, nextStep, attemptID, payload)

--- a/clients/catalyst.go
+++ b/clients/catalyst.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"net/url"
 	"path"
+	"strconv"
 
 	"github.com/golang/glog"
 	"github.com/livepeer/catalyst-api/clients"
@@ -48,7 +49,7 @@ type CatalystCallback = clients.TranscodeStatusCompletedMessage
 
 type Catalyst interface {
 	UploadVOD(ctx context.Context, upload UploadVODRequest) error
-	CatalystHookURL(taskId, nextStep string) string
+	CatalystHookURL(taskId, nextStep string, attemptID int) string
 }
 
 func NewCatalyst(opts CatalystOptions) Catalyst {
@@ -83,11 +84,12 @@ func (c *catalyst) UploadVOD(ctx context.Context, upload UploadVODRequest) error
 
 // Catalyst hook helpers
 
-func (c *catalyst) CatalystHookURL(taskId, nextStep string) string {
+func (c *catalyst) CatalystHookURL(taskId, nextStep string, attemptID int) string {
 	// Own base URL already includes root path, so no need to add it
 	hookURL := c.OwnBaseURL.JoinPath(CatalystHookPath("", taskId))
 	query := hookURL.Query()
 	query.Set("nextStep", nextStep)
+	query.Set("attemptId", strconv.Itoa(attemptID))
 	hookURL.RawQuery = query.Encode()
 	return hookURL.String()
 }

--- a/clients/catalyst.go
+++ b/clients/catalyst.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"net/url"
 	"path"
-	"strconv"
 
 	"github.com/golang/glog"
 	"github.com/livepeer/catalyst-api/clients"
@@ -49,7 +48,7 @@ type CatalystCallback = clients.TranscodeStatusCompletedMessage
 
 type Catalyst interface {
 	UploadVOD(ctx context.Context, upload UploadVODRequest) error
-	CatalystHookURL(taskId, nextStep string, attemptID int) string
+	CatalystHookURL(taskId, nextStep, attemptID string) string
 }
 
 func NewCatalyst(opts CatalystOptions) Catalyst {
@@ -84,12 +83,12 @@ func (c *catalyst) UploadVOD(ctx context.Context, upload UploadVODRequest) error
 
 // Catalyst hook helpers
 
-func (c *catalyst) CatalystHookURL(taskId, nextStep string, attemptID int) string {
+func (c *catalyst) CatalystHookURL(taskId, nextStep, attemptID string) string {
 	// Own base URL already includes root path, so no need to add it
 	hookURL := c.OwnBaseURL.JoinPath(CatalystHookPath("", taskId))
 	query := hookURL.Query()
 	query.Set("nextStep", nextStep)
-	query.Set("attemptId", strconv.Itoa(attemptID))
+	query.Set("attemptId", attemptID)
 	hookURL.RawQuery = query.Encode()
 	return hookURL.String()
 }

--- a/task/progress.go
+++ b/task/progress.go
@@ -110,7 +110,7 @@ func (p *ProgressReporter) reportOnce() {
 		}
 		return
 	}
-	if !shouldReportProgress(progress, p.lastProgress, p.lastReport) {
+	if !shouldReportProgress(progress, p.lastProgress, p.taskID, p.lastReport) {
 		return
 	}
 	if err := p.lapi.UpdateTaskStatus(p.taskID, "running", progress); err != nil {
@@ -120,10 +120,13 @@ func (p *ProgressReporter) reportOnce() {
 	p.lastReport, p.lastProgress = time.Now(), progress
 }
 
-func shouldReportProgress(new, old float64, lastReportedAt time.Time) bool {
+func shouldReportProgress(new, old float64, taskID string, lastReportedAt time.Time) bool {
 	// Catalyst currently sends non monotonic progress updates, so we only update
-	// the progress if it's equal or higher than the current one.
-	if old >= new {
+	// the progress if it's higher than the current one.
+	if new <= old {
+		if new < old {
+			glog.Warningf("Non monotonic progress received taskID=%s lastProgress=%v progress=%v", taskID, old, new)
+		}
 		return false
 	}
 	return progressBucket(new) != progressBucket(old) ||

--- a/task/progress.go
+++ b/task/progress.go
@@ -121,6 +121,11 @@ func (p *ProgressReporter) reportOnce() {
 }
 
 func shouldReportProgress(new, old float64, lastReportedAt time.Time) bool {
+	// Catalyst currently sends non monotonic progress updates, so we only update
+	// the progress if it's equal or higher than the current one.
+	if old >= new {
+		return false
+	}
 	return progressBucket(new) != progressBucket(old) ||
 		time.Since(lastReportedAt) >= minProgressReportInterval
 }

--- a/task/progress.go
+++ b/task/progress.go
@@ -122,11 +122,9 @@ func (p *ProgressReporter) reportOnce() {
 
 func shouldReportProgress(new, old float64, taskID string, lastReportedAt time.Time) bool {
 	// Catalyst currently sends non monotonic progress updates, so we only update
-	// the progress if it's higher than the current one.
-	if new <= old {
-		if new < old {
-			glog.Warningf("Non monotonic progress received taskID=%s lastProgress=%v progress=%v", taskID, old, new)
-		}
+	// the progress if the new value is not less than the old one.
+	if new < old {
+		glog.Warningf("Non monotonic progress received taskID=%s lastProgress=%v progress=%v", taskID, old, new)
 		return false
 	}
 	return progressBucket(new) != progressBucket(old) ||

--- a/task/runner.go
+++ b/task/runner.go
@@ -298,7 +298,7 @@ func (r *runner) HandleCatalysis(ctx context.Context, taskId, nextStep, attemptI
 	progress := 0.9 * callback.CompletionRatio
 	progress = math.Round(progress*1000) / 1000
 	currProgress, taskUpdatedAt := task.Status.Progress, data.NewUnixMillisTime(task.Status.UpdatedAt)
-	if shouldReportProgress(progress, currProgress, taskUpdatedAt.Time) {
+	if shouldReportProgress(progress, currProgress, task.ID, taskUpdatedAt.Time) {
 		err = r.lapi.UpdateTaskStatus(task.ID, api.TaskPhaseRunning, progress)
 		if err != nil {
 			glog.Warningf("Failed to update task progress. taskID=%s err=%v", task.ID, err)

--- a/task/runner.go
+++ b/task/runner.go
@@ -298,9 +298,7 @@ func (r *runner) HandleCatalysis(ctx context.Context, taskId, nextStep, attemptI
 	progress := 0.9 * callback.CompletionRatio
 	progress = math.Round(progress*1000) / 1000
 	currProgress, taskUpdatedAt := task.Status.Progress, data.NewUnixMillisTime(task.Status.UpdatedAt)
-	// Catalyst currently sends non monotonic progress updates, so we only update
-	// the progress if it's higher than the current one
-	if progress > currProgress && shouldReportProgress(progress, currProgress, taskUpdatedAt.Time) {
+	if shouldReportProgress(progress, currProgress, taskUpdatedAt.Time) {
 		err = r.lapi.UpdateTaskStatus(task.ID, api.TaskPhaseRunning, progress)
 		if err != nil {
 			glog.Warningf("Failed to update task progress. taskID=%s err=%v", task.ID, err)

--- a/task/runner.go
+++ b/task/runner.go
@@ -56,7 +56,7 @@ func (t *TaskContext) WithContext(ctx context.Context) *TaskContext {
 
 type Runner interface {
 	Start() error
-	HandleCatalysis(ctx context.Context, taskId, nextStep string, retries *int, callback *clients.CatalystCallback) error
+	HandleCatalysis(ctx context.Context, taskId, nextStep string, attemptID *int, callback *clients.CatalystCallback) error
 	Shutdown(ctx context.Context) error
 }
 
@@ -281,7 +281,7 @@ func (r *runner) getAssetAndOS(assetID string) (*api.Asset, *api.ObjectStore, dr
 	return asset, objectStore, osSession, nil
 }
 
-func (r *runner) HandleCatalysis(ctx context.Context, taskId, nextStep string, retries *int, callback *clients.CatalystCallback) error {
+func (r *runner) HandleCatalysis(ctx context.Context, taskId, nextStep string, attemptID *int, callback *clients.CatalystCallback) error {
 	taskInfo, task, err := r.getTaskInfo(taskId, "catalysis", nil)
 	if err != nil {
 		return fmt.Errorf("failed to get task %s: %w", taskId, err)
@@ -291,9 +291,9 @@ func (r *runner) HandleCatalysis(ctx context.Context, taskId, nextStep string, r
 	if task.Status.Phase != api.TaskPhaseRunning &&
 		task.Status.Phase != api.TaskPhaseWaiting {
 		return fmt.Errorf("task %s is not running", taskId)
-	} else if retries != nil && *retries != task.Status.Retries {
+	} else if attemptID != nil && *attemptID != task.Status.Retries {
 		return fmt.Errorf("outdated catalyst job callback, "+
-			"task has already been retried (callback: %d current: %d)", *retries, task.Status.Retries)
+			"task has already been retried (callback: %d current: %d)", *attemptID, task.Status.Retries)
 	}
 	progress := 0.9 * callback.CompletionRatio
 	progress = math.Round(progress*1000) / 1000

--- a/task/upload.go
+++ b/task/upload.go
@@ -51,7 +51,7 @@ func TaskUpload(tctx *TaskContext) (*data.TaskOutput, error) {
 		}
 		uploadReq := clients.UploadVODRequest{
 			Url:             inUrl,
-			CallbackUrl:     tctx.catalyst.CatalystHookURL(tctx.Task.ID, "finalize"),
+			CallbackUrl:     tctx.catalyst.CatalystHookURL(tctx.Task.ID, "finalize", tctx.Status.Retries),
 			OutputLocations: outputLocations,
 		}
 		if err := tctx.catalyst.UploadVOD(ctx, uploadReq); err != nil {

--- a/task/upload.go
+++ b/task/upload.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/url"
 	"path"
+	"strconv"
 	"strings"
 	"time"
 
@@ -51,7 +52,7 @@ func TaskUpload(tctx *TaskContext) (*data.TaskOutput, error) {
 		}
 		uploadReq := clients.UploadVODRequest{
 			Url:             inUrl,
-			CallbackUrl:     tctx.catalyst.CatalystHookURL(tctx.Task.ID, "finalize", tctx.Status.Retries),
+			CallbackUrl:     tctx.catalyst.CatalystHookURL(tctx.Task.ID, "finalize", catalystTaskAttemptID(tctx.Task)),
 			OutputLocations: outputLocations,
 		}
 		if err := tctx.catalyst.UploadVOD(ctx, uploadReq); err != nil {
@@ -374,4 +375,10 @@ func assetOutputLocations(tctx *TaskContext) ([]OutputName, []clients.OutputLoca
 			})
 	}
 	return names, locations, nil
+}
+
+func catalystTaskAttemptID(task *api.Task) string {
+	// Simplest way to identify unique runs of a given task. We should think of
+	// something more sophisticated in the future.
+	return strconv.Itoa(task.Status.Retries)
 }


### PR DESCRIPTION
Today if a task is retried and the old catalyst job keeps sending callbacks to task-runner, we have
no way of differentiating those vs the actual callbacks we want to receive from the new job.

To fix this, added an `attemptId` query-string on the callback URLs so that task-runner can identify
the unique runs. This is not perfect, as if we start multiple jobs on the same task retry (e.g. event was
nacked and retried on RabbitMQ) we could still confuse the runs. 

It is already much better than before tho, as the direct-RabbitMQ retry is much rarer, and also easy to
evolve if we ever create some "internal storage" for the task runs to store intermediate data 
(like the Catalyst request ID). While we don't have that, this was the easiest I could think of.

