### PR TITLE
clients: Add rate limit handling to catalyst client

### DIFF
--- a/clients/catalyst.go
+++ b/clients/catalyst.go
@@ -19,6 +19,8 @@ var (
 	ErrRateLimited        = errors.New("rate limited")
 	CatalystStatusSuccess = clients.TranscodeStatusCompleted.String()
 	CatalystStatusError   = clients.TranscodeStatusError.String()
+
+	baseTransport = *http.DefaultTransport.(*http.Transport)
 )
 
 const (
@@ -59,10 +61,15 @@ type Catalyst interface {
 }
 
 func NewCatalyst(opts CatalystOptions) Catalyst {
+	transport := baseTransport
+	transport.DisableKeepAlives = true
 	return &catalyst{opts, BaseClient{
 		BaseUrl: opts.BaseURL,
 		BaseHeaders: map[string]string{
 			"Authorization": "Bearer " + opts.Secret,
+		},
+		Client: &http.Client{
+			Transport: &transport,
 		},
 	}}
 }


### PR DESCRIPTION
Simple logic, just waiting 15 seconds between each attempt. Should be fine since the request is also really cheap on catalyst side when it gets rate limited, and there will be at most 5 of these looping per task runner instance (3 instances)

My only concern now is that if we're operating at full capacity, these 5 executions will also block handling of any events from the currently running jobs. So we might stop checking if we're getting catalyst callbacks and handling the result callbacks (they become events as well).

Should consider reusing the "delayed task" abstraction used for checking catalyst callbacks for this as well, as a pre-step on the upload task execution in case it got rate limited.

Edit: Fixed the above and implemented an async back off through the delayed event.