### PR TITLE
task/runner: Several reliability improvements 

### DIFF
--- a/cmd/task-runner/task-runner.go
+++ b/cmd/task-runner/task-runner.go
@@ -89,7 +89,7 @@ func parseFlags(build BuildFlags) cliFlags {
 	fs.StringVar(&cli.runnerOpts.ExchangeName, "exchange-name", "lp_tasks", "Name of exchange where the task events will be published to")
 	fs.StringVar(&cli.runnerOpts.QueueName, "queue-name", "lp_runner_task_queue", "Name of task queue to consume from. If it doesn't exist a new queue will be created and bound to the API exchange")
 	fs.StringVar(&cli.runnerOpts.OldQueueName, "old-queue-name", "", "Name of the old task queue that should be unbound and attempted a clean-up")
-	fs.StringVar(&cli.runnerOpts.DeadLetter.ExchangeName, "dead-letter-exchange-name", "lp_dead_tasks", "Name of the dead letter exchange to create for tasks that are unprocessable")
+	fs.StringVar(&cli.runnerOpts.DeadLetter.ExchangeName, "dead-letter-exchange-name", "", "Name of the dead letter exchange to create for tasks that are unprocessable")
 	fs.StringVar(&cli.runnerOpts.DeadLetter.QueueName, "dead-letter-queue-name", "", "Name of the queue where the dead-lettered tasks should be routed to. This queue is not consumed automatically. If empty, the name will be the same as the dead-letter exchange")
 	fs.DurationVar(&cli.runnerOpts.MinTaskProcessingTime, "min-task-processing-time", task.DefaultMinTaskProcessingTime, "Minimum time that a task processing must take as rate-limiting strategy. If the task finishes earlier, the runner will wait for the remaining time before starting another task")
 	fs.DurationVar(&cli.runnerOpts.MaxTaskProcessingTime, "max-task-processing-time", task.DefaultMaxTaskProcessingTime, "Timeout for task processing. If the task is not completed within this time it will be marked as failed")

--- a/cmd/task-runner/task-runner.go
+++ b/cmd/task-runner/task-runner.go
@@ -88,6 +88,8 @@ func parseFlags(build BuildFlags) cliFlags {
 	fs.StringVar(&cli.runnerOpts.AMQPUri, "amqp-uri", "amqp://guest:guest@localhost:5672/livepeer", "URI for RabbitMQ server to consume from. Specified in the AMQP protocol")
 	fs.StringVar(&cli.runnerOpts.ExchangeName, "exchange-name", "lp_tasks", "Name of exchange where the task events will be published to")
 	fs.StringVar(&cli.runnerOpts.QueueName, "queue-name", "lp_runner_task_queue", "Name of task queue to consume from. If it doesn't exist a new queue will be created and bound to the API exchange")
+	fs.StringVar(&cli.runnerOpts.DeadLetter.ExchangeName, "dead-letter-exchange-name", "lp_dead_tasks", "Name of the dead letter exchange to create for tasks that are unprocessable")
+	fs.StringVar(&cli.runnerOpts.DeadLetter.QueueName, "dead-letter-queue-name", "", "Name of the queue where the dead-lettered tasks should be routed to. This queue is not consumed automatically. If empty, the name will be the same as the dead-letter exchange")
 	fs.DurationVar(&cli.runnerOpts.MinTaskProcessingTime, "min-task-processing-time", task.DefaultMinTaskProcessingTime, "Minimum time that a task processing must take as rate-limiting strategy. If the task finishes earlier, the runner will wait for the remaining time before starting another task")
 	fs.DurationVar(&cli.runnerOpts.MaxTaskProcessingTime, "max-task-processing-time", task.DefaultMaxTaskProcessingTime, "Timeout for task processing. If the task is not completed within this time it will be marked as failed")
 	fs.UintVar(&cli.runnerOpts.MaxConcurrentTasks, "max-concurrent-tasks", task.DefaultMaxConcurrentTasks, "Maximum number of tasks to run simultaneously")

--- a/cmd/task-runner/task-runner.go
+++ b/cmd/task-runner/task-runner.go
@@ -88,6 +88,7 @@ func parseFlags(build BuildFlags) cliFlags {
 	fs.StringVar(&cli.runnerOpts.AMQPUri, "amqp-uri", "amqp://guest:guest@localhost:5672/livepeer", "URI for RabbitMQ server to consume from. Specified in the AMQP protocol")
 	fs.StringVar(&cli.runnerOpts.ExchangeName, "exchange-name", "lp_tasks", "Name of exchange where the task events will be published to")
 	fs.StringVar(&cli.runnerOpts.QueueName, "queue-name", "lp_runner_task_queue", "Name of task queue to consume from. If it doesn't exist a new queue will be created and bound to the API exchange")
+	fs.StringVar(&cli.runnerOpts.OldQueueName, "old-queue-name", "", "Name of the old task queue that should be unbound and attempted a clean-up")
 	fs.StringVar(&cli.runnerOpts.DeadLetter.ExchangeName, "dead-letter-exchange-name", "lp_dead_tasks", "Name of the dead letter exchange to create for tasks that are unprocessable")
 	fs.StringVar(&cli.runnerOpts.DeadLetter.QueueName, "dead-letter-queue-name", "", "Name of the queue where the dead-lettered tasks should be routed to. This queue is not consumed automatically. If empty, the name will be the same as the dead-letter exchange")
 	fs.DurationVar(&cli.runnerOpts.MinTaskProcessingTime, "min-task-processing-time", task.DefaultMinTaskProcessingTime, "Minimum time that a task processing must take as rate-limiting strategy. If the task finishes earlier, the runner will wait for the remaining time before starting another task")

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/livepeer/go-api-client v0.4.1-0.20221207101406-c3675c55eed5
 	github.com/livepeer/go-tools v0.1.0
 	github.com/livepeer/joy4 v0.1.2-0.20220210094601-95e4d28f5f07
-	github.com/livepeer/livepeer-data v0.6.0
+	github.com/livepeer/livepeer-data v0.6.2
 	github.com/livepeer/stream-tester v0.12.22-0.20220912212136-f2dff6bd9343
 	github.com/peterbourgon/ff v1.7.1
 	github.com/prometheus/client_golang v1.14.0

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/livepeer/go-api-client v0.4.1-0.20221207101406-c3675c55eed5
 	github.com/livepeer/go-tools v0.1.0
 	github.com/livepeer/joy4 v0.1.2-0.20220210094601-95e4d28f5f07
-	github.com/livepeer/livepeer-data v0.5.2
+	github.com/livepeer/livepeer-data v0.5.3-0.20221206125757-0d5424656595
 	github.com/livepeer/stream-tester v0.12.22-0.20220912212136-f2dff6bd9343
 	github.com/peterbourgon/ff v1.7.1
 	github.com/prometheus/client_golang v1.14.0

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/livepeer/go-api-client v0.4.1-0.20221207101406-c3675c55eed5
 	github.com/livepeer/go-tools v0.1.0
 	github.com/livepeer/joy4 v0.1.2-0.20220210094601-95e4d28f5f07
-	github.com/livepeer/livepeer-data v0.5.3-0.20221206125757-0d5424656595
+	github.com/livepeer/livepeer-data v0.6.0
 	github.com/livepeer/stream-tester v0.12.22-0.20220912212136-f2dff6bd9343
 	github.com/peterbourgon/ff v1.7.1
 	github.com/prometheus/client_golang v1.14.0

--- a/go.sum
+++ b/go.sum
@@ -315,8 +315,8 @@ github.com/livepeer/go-tools v0.1.0 h1:GOZwUL2ME8aJOEyusmBrj056NucRFcaGTnTbQ8koB
 github.com/livepeer/go-tools v0.1.0/go.mod h1:aLVS1DT0ur9kpr0IlNI4DNcm9vVjRRUjDnwuEUm0BdQ=
 github.com/livepeer/joy4 v0.1.2-0.20220210094601-95e4d28f5f07 h1:ISkFQYYDgfnM6Go+VyemF66DKFc8kNoI9SwMv7GC9sM=
 github.com/livepeer/joy4 v0.1.2-0.20220210094601-95e4d28f5f07/go.mod h1:RDTLvmm/NJWjzuUpEDyIWmLTqSfpZEcnPnacG8sfh34=
-github.com/livepeer/livepeer-data v0.5.2 h1:PS1uXm6VUZdW/gbChGp2jB1r8P5YjWbUJnodJzOuEyY=
-github.com/livepeer/livepeer-data v0.5.2/go.mod h1:6xP6P9IzKaenw9jJoxkcZzJx1qSQe3UBYKUBZ61gXl8=
+github.com/livepeer/livepeer-data v0.5.3-0.20221206125757-0d5424656595 h1:cLAoarZGDEVOiMLDGKfPaojb2cm793rt5nJiNDyOrvk=
+github.com/livepeer/livepeer-data v0.5.3-0.20221206125757-0d5424656595/go.mod h1:6xP6P9IzKaenw9jJoxkcZzJx1qSQe3UBYKUBZ61gXl8=
 github.com/livepeer/m3u8 v0.11.1 h1:VkUJzfNTyjy9mqsgp5JPvouwna8wGZMvd/gAfT5FinU=
 github.com/livepeer/m3u8 v0.11.1/go.mod h1:IUqAtwWPAG2CblfQa4SVzTQoDcEMPyfNOaBSxqHMS04=
 github.com/livepeer/stream-tester v0.12.22-0.20220912212136-f2dff6bd9343 h1:9mAQMfQGIpv7+0X6Z8+qag6zag+/r+zsqLJGB00n+pc=

--- a/go.sum
+++ b/go.sum
@@ -315,8 +315,8 @@ github.com/livepeer/go-tools v0.1.0 h1:GOZwUL2ME8aJOEyusmBrj056NucRFcaGTnTbQ8koB
 github.com/livepeer/go-tools v0.1.0/go.mod h1:aLVS1DT0ur9kpr0IlNI4DNcm9vVjRRUjDnwuEUm0BdQ=
 github.com/livepeer/joy4 v0.1.2-0.20220210094601-95e4d28f5f07 h1:ISkFQYYDgfnM6Go+VyemF66DKFc8kNoI9SwMv7GC9sM=
 github.com/livepeer/joy4 v0.1.2-0.20220210094601-95e4d28f5f07/go.mod h1:RDTLvmm/NJWjzuUpEDyIWmLTqSfpZEcnPnacG8sfh34=
-github.com/livepeer/livepeer-data v0.6.0 h1:UjiT4ESM6QWR5JTf+3BuNmSohOPVQDlZ1n1bVHlxZoE=
-github.com/livepeer/livepeer-data v0.6.0/go.mod h1:6xP6P9IzKaenw9jJoxkcZzJx1qSQe3UBYKUBZ61gXl8=
+github.com/livepeer/livepeer-data v0.6.2 h1:b/+CppOJsXipt2eBwTBnW1ldGu+2HVVQsV+iq65x73E=
+github.com/livepeer/livepeer-data v0.6.2/go.mod h1:6xP6P9IzKaenw9jJoxkcZzJx1qSQe3UBYKUBZ61gXl8=
 github.com/livepeer/m3u8 v0.11.1 h1:VkUJzfNTyjy9mqsgp5JPvouwna8wGZMvd/gAfT5FinU=
 github.com/livepeer/m3u8 v0.11.1/go.mod h1:IUqAtwWPAG2CblfQa4SVzTQoDcEMPyfNOaBSxqHMS04=
 github.com/livepeer/stream-tester v0.12.22-0.20220912212136-f2dff6bd9343 h1:9mAQMfQGIpv7+0X6Z8+qag6zag+/r+zsqLJGB00n+pc=

--- a/go.sum
+++ b/go.sum
@@ -315,8 +315,8 @@ github.com/livepeer/go-tools v0.1.0 h1:GOZwUL2ME8aJOEyusmBrj056NucRFcaGTnTbQ8koB
 github.com/livepeer/go-tools v0.1.0/go.mod h1:aLVS1DT0ur9kpr0IlNI4DNcm9vVjRRUjDnwuEUm0BdQ=
 github.com/livepeer/joy4 v0.1.2-0.20220210094601-95e4d28f5f07 h1:ISkFQYYDgfnM6Go+VyemF66DKFc8kNoI9SwMv7GC9sM=
 github.com/livepeer/joy4 v0.1.2-0.20220210094601-95e4d28f5f07/go.mod h1:RDTLvmm/NJWjzuUpEDyIWmLTqSfpZEcnPnacG8sfh34=
-github.com/livepeer/livepeer-data v0.5.3-0.20221206125757-0d5424656595 h1:cLAoarZGDEVOiMLDGKfPaojb2cm793rt5nJiNDyOrvk=
-github.com/livepeer/livepeer-data v0.5.3-0.20221206125757-0d5424656595/go.mod h1:6xP6P9IzKaenw9jJoxkcZzJx1qSQe3UBYKUBZ61gXl8=
+github.com/livepeer/livepeer-data v0.6.0 h1:UjiT4ESM6QWR5JTf+3BuNmSohOPVQDlZ1n1bVHlxZoE=
+github.com/livepeer/livepeer-data v0.6.0/go.mod h1:6xP6P9IzKaenw9jJoxkcZzJx1qSQe3UBYKUBZ61gXl8=
 github.com/livepeer/m3u8 v0.11.1 h1:VkUJzfNTyjy9mqsgp5JPvouwna8wGZMvd/gAfT5FinU=
 github.com/livepeer/m3u8 v0.11.1/go.mod h1:IUqAtwWPAG2CblfQa4SVzTQoDcEMPyfNOaBSxqHMS04=
 github.com/livepeer/stream-tester v0.12.22-0.20220912212136-f2dff6bd9343 h1:9mAQMfQGIpv7+0X6Z8+qag6zag+/r+zsqLJGB00n+pc=

--- a/task/prepare.go
+++ b/task/prepare.go
@@ -71,7 +71,7 @@ func Prepare(tctx *TaskContext, assetSpec *api.AssetSpec, file io.ReadSeekCloser
 	if err != nil {
 		return "", err
 	}
-	stream, err := lapi.CreateStreamR(api.CreateStreamReq{Name: streamName, Record: true, Profiles: profiles})
+	stream, err := lapi.CreateStream(api.CreateStreamReq{Name: streamName, Record: true, Profiles: profiles})
 	if err != nil {
 		return "", err
 	}
@@ -110,7 +110,7 @@ func Prepare(tctx *TaskContext, assetSpec *api.AssetSpec, file io.ReadSeekCloser
 		glog.V(model.VERBOSE).Infof("Got segment seqNo=%d pts=%s dur=%s data len bytes=%d\n", seg.SeqNo, seg.Pts, seg.Duration, len(seg.Data))
 		accumulator.Accumulate(uint64(len(seg.Data)))
 		started := time.Now()
-		_, err = lapi.PushSegmentR(stream.ID, seg.SeqNo, seg.Duration, seg.Data, contentResolution)
+		_, err = lapi.PushSegment(stream.ID, seg.SeqNo, seg.Duration, seg.Data, contentResolution)
 		if err != nil {
 			glog.Errorf("Error while segment push for prepare err=%v\n", err)
 			break

--- a/task/runner.go
+++ b/task/runner.go
@@ -535,6 +535,7 @@ func publishLoggedRaw(producer event.AMQPProducer, task data.TaskInfo, exchange,
 		Key:        key,
 		Body:       body,
 		Persistent: true,
+		// TODO: Actually handle returns from the AMQP server. Needs further support in pkg/event.
 		Mandatory:  true,
 		WaitResult: true,
 	}

--- a/task/runner.go
+++ b/task/runner.go
@@ -539,8 +539,8 @@ func publishLoggedRaw(producer event.AMQPProducer, task data.TaskInfo, exchange,
 		Key:        key,
 		Body:       body,
 		Persistent: true,
-		// TODO: Actually handle returns from the AMQP server. Needs further support in pkg/event.
-		Mandatory:  true,
+		// TODO: Actually handle returns from the AMQP server so we can toggle mandatory here. Needs further support in pkg/event.
+		// Mandatory:  true,
 		WaitResult: true,
 	}
 	glog.Infof("Publishing AMQP message. taskType=%q id=%s step=%q exchange=%q key=%q body=%+v", task.Type, task.ID, task.Step, exchange, key, body)

--- a/task/runner.go
+++ b/task/runner.go
@@ -255,7 +255,7 @@ func parseTaskInfo(msg amqp.Delivery) (data.TaskInfo, error) {
 }
 
 func (r *runner) buildTaskContext(ctx context.Context, info data.TaskInfo) (*TaskContext, error) {
-	task, err := r.lapi.GetTask(info.ID)
+	task, err := r.lapi.GetTask(info.ID, true)
 	if err != nil {
 		return nil, err
 	}
@@ -275,7 +275,7 @@ func (r *runner) getAssetAndOS(assetID string) (*api.Asset, *api.ObjectStore, dr
 	if assetID == "" {
 		return nil, nil, nil, nil
 	}
-	asset, err := r.lapi.GetAsset(assetID)
+	asset, err := r.lapi.GetAsset(assetID, true)
 	if err != nil {
 		return nil, nil, nil, err
 	}
@@ -372,7 +372,7 @@ func (r *runner) publishTaskResult(ctx context.Context, task data.TaskInfo, outp
 }
 
 func (r *runner) getTaskInfo(id, step string, input interface{}) (data.TaskInfo, *api.Task, error) {
-	task, err := r.lapi.GetTask(id)
+	task, err := r.lapi.GetTask(id, true)
 	if err != nil {
 		return data.TaskInfo{}, nil, fmt.Errorf("error getting task %q: %w", id, err)
 	}

--- a/task/runner.go
+++ b/task/runner.go
@@ -232,7 +232,7 @@ func (r *runner) handleTask(ctx context.Context, taskInfo data.TaskInfo) (out *T
 
 		err = r.lapi.UpdateTaskStatus(taskID, api.TaskPhaseRunning, 0)
 		if err == api.ErrRateLimited {
-			glog.Warning("Task execution rate limited type=%q id=%s userID=%s", taskType, taskID, taskCtx.UserID)
+			glog.Warningf("Task execution rate limited type=%q id=%s userID=%s", taskType, taskID, taskCtx.UserID)
 			return nil, r.delayTaskStep(ctx, taskID, taskCtx.Step, taskCtx.StepInput)
 		} else if err != nil {
 			glog.Errorf("Error updating task progress type=%q id=%s err=%q unretriable=%v", taskType, taskID, err, IsUnretriable(err))

--- a/task/runner.go
+++ b/task/runner.go
@@ -535,6 +535,7 @@ func publishLoggedRaw(producer event.AMQPProducer, task data.TaskInfo, exchange,
 		Key:        key,
 		Body:       body,
 		Persistent: true,
+		Mandatory:  true,
 		WaitResult: true,
 	}
 	glog.Infof("Publishing AMQP message. taskType=%q id=%s step=%q exchange=%q key=%q body=%+v", task.Type, task.ID, task.Step, exchange, key, body)

--- a/task/runner.go
+++ b/task/runner.go
@@ -455,6 +455,7 @@ func humanizeError(err error) error {
 		strings.Contains(errMsg, "could not create stream id") ||
 		strings.Contains(errMsg, "502 bad gateway") ||
 		strings.Contains(errMsg, "task has already been started before") ||
+		strings.Contains(errMsg, "catalyst task lost") ||
 		(strings.Contains(errMsg, "eof") && strings.Contains(errMsg, "error processing file"))
 
 	if isProcessing {

--- a/task/runner.go
+++ b/task/runner.go
@@ -481,6 +481,10 @@ func humanizeError(err error) error {
 	if errors.As(err, &catErr) {
 		if strings.Contains(errMsg, "unsupported input pixel format") {
 			return errors.New("unsupported input pixel format, must be 'yuv420p' or 'yuvj420p'")
+		} else if strings.Contains(errMsg, "Unsupported video input") {
+			return errors.New("unsupported file format")
+		} else if strings.Contains(errMsg, "ReadPacketData File read failed - end of file hit") {
+			return errors.New("invalid video file, possibly truncated")
 		}
 		return errInternalProcessingError
 	}

--- a/task/runner.go
+++ b/task/runner.go
@@ -231,7 +231,10 @@ func (r *runner) handleTask(ctx context.Context, taskInfo data.TaskInfo) (out *T
 		}
 
 		err = r.lapi.UpdateTaskStatus(taskID, api.TaskPhaseRunning, 0)
-		if err != nil {
+		if err == api.ErrRateLimited {
+			glog.Warning("Task execution rate limited type=%q id=%s userID=%s", taskType, taskID, taskCtx.UserID)
+			return nil, r.delayTaskStep(ctx, taskID, taskCtx.Step, taskCtx.StepInput)
+		} else if err != nil {
 			glog.Errorf("Error updating task progress type=%q id=%s err=%q unretriable=%v", taskType, taskID, err, IsUnretriable(err))
 			// execute the task anyway
 		}

--- a/task/runner.go
+++ b/task/runner.go
@@ -161,7 +161,7 @@ func (r *runner) setupAmqpConnection(c event.AMQPChanSetup) error {
 
 	err := declareQueueAndExchange(c, r.ExchangeName, r.QueueName, "task.trigger.#", queueArgs)
 	if err != nil {
-		return fmt.Errorf("error declaring main exchange: %w", err)
+		return err
 	}
 
 	queueArgs = amqp.Table{

--- a/task/runner.go
+++ b/task/runner.go
@@ -205,7 +205,7 @@ func (r *runner) handleAMQPMessage(msg amqp.Delivery) (err error) {
 	task, err := parseTaskInfo(msg)
 	if err != nil {
 		glog.Errorf("Error parsing AMQP message err=%q msg=%q", err, msg.Body)
-		return event.UnprocessableIfErr(err)
+		return event.UnprocessableMsgErr(err)
 	}
 	defer func() {
 		if rec := recover(); rec != nil {

--- a/task/runner.go
+++ b/task/runner.go
@@ -316,8 +316,10 @@ func (r *runner) HandleCatalysis(ctx context.Context, taskId, nextStep, attemptI
 	if err != nil {
 		return fmt.Errorf("failed to get task %s: %w", taskId, err)
 	}
+
 	glog.Infof("Received catalyst callback taskType=%q id=%s taskPhase=%s status=%q completionRatio=%v error=%q rawCallback=%+v",
 		task.Type, task.ID, task.Status.Phase, callback.Status, callback.CompletionRatio, callback.Error, *callback)
+
 	if task.Status.Phase != api.TaskPhaseRunning &&
 		task.Status.Phase != api.TaskPhaseWaiting {
 		return fmt.Errorf("task %s is not running", taskId)
@@ -325,6 +327,7 @@ func (r *runner) HandleCatalysis(ctx context.Context, taskId, nextStep, attemptI
 		return fmt.Errorf("outdated catalyst job callback, "+
 			"task has already been retried (callback: %s current: %s)", attemptID, curr)
 	}
+
 	progress := 0.9 * callback.CompletionRatio
 	progress = math.Round(progress*1000) / 1000
 	currProgress, taskUpdatedAt := task.Status.Progress, data.NewUnixMillisTime(task.Status.UpdatedAt)
@@ -334,6 +337,7 @@ func (r *runner) HandleCatalysis(ctx context.Context, taskId, nextStep, attemptI
 			glog.Warningf("Failed to update task progress. taskID=%s err=%v", task.ID, err)
 		}
 	}
+
 	if callback.Status == clients.CatalystStatusError {
 		glog.Infof("Catalyst job failed for task type=%q id=%s error=%q unretriable=%v", task.Type, task.ID, callback.Error, callback.Unretriable)
 		err := NewCatalystError(callback.Error, callback.Unretriable)
@@ -341,6 +345,7 @@ func (r *runner) HandleCatalysis(ctx context.Context, taskId, nextStep, attemptI
 	} else if callback.Status == clients.CatalystStatusSuccess {
 		return r.scheduleTaskStep(ctx, task.ID, nextStep, callback)
 	}
+
 	return nil
 }
 

--- a/task/runner_test.go
+++ b/task/runner_test.go
@@ -1,0 +1,66 @@
+package task
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/livepeer/livepeer-data/pkg/data"
+	"github.com/livepeer/livepeer-data/pkg/event"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSimplePublishErrorDoesNotPanic(t *testing.T) {
+	require := require.New(t)
+
+	var publishedMsg *event.AMQPMessage
+	producer := func(ctx context.Context, msg event.AMQPMessage) error {
+		require.Nil(publishedMsg)
+		publishedMsg = &msg
+		return nil
+	}
+
+	exchange, taskInfo := "uniswap", data.TaskInfo{
+		ID:   "LPT",
+		Type: "ICO",
+		Step: "merkle_mine",
+	}
+	var err error
+	require.NotPanics(func() {
+		err = simplePublishTaskFatalError(context.Background(), producerFunc(producer), exchange, taskInfo)
+	})
+	require.NoError(err)
+	require.NotNil(publishedMsg)
+
+	require.IsType(&data.TaskResultEvent{}, publishedMsg.Body)
+	base := publishedMsg.Body.(*data.TaskResultEvent).Base
+
+	require.NotZero(base.ID())
+	require.Equal(data.EventTypeTaskResult, base.Type())
+	require.LessOrEqual(time.Since(base.Timestamp()), 1*time.Second)
+
+	require.Equal(*publishedMsg, event.AMQPMessage{
+		Exchange:   "uniswap",
+		Key:        "task.result.ICO.LPT",
+		Persistent: true,
+		WaitResult: true,
+		Body: &data.TaskResultEvent{
+			Base: base,
+			Task: taskInfo,
+			Error: &data.ErrorInfo{
+				Message:     "internal error processing file",
+				Unretriable: true,
+			},
+		},
+	})
+}
+
+type producerFunc func(ctx context.Context, msg event.AMQPMessage) error
+
+func (f producerFunc) Publish(ctx context.Context, msg event.AMQPMessage) error {
+	return f(ctx, msg)
+}
+
+func (f producerFunc) Shutdown(ctx context.Context) error {
+	return nil
+}

--- a/task/runner_test.go
+++ b/task/runner_test.go
@@ -43,7 +43,7 @@ func TestSimplePublishErrorDoesNotPanic(t *testing.T) {
 		Exchange:   "uniswap",
 		Key:        "task.result.ICO.LPT",
 		Persistent: true,
-		Mandatory:  true,
+		Mandatory:  false,
 		WaitResult: true,
 		Body: &data.TaskResultEvent{
 			Base: base,

--- a/task/runner_test.go
+++ b/task/runner_test.go
@@ -27,7 +27,7 @@ func TestSimplePublishErrorDoesNotPanic(t *testing.T) {
 	}
 	var err error
 	require.NotPanics(func() {
-		err = simplePublishTaskFatalError(context.Background(), producerFunc(producer), exchange, taskInfo)
+		err = simplePublishTaskFatalError(producerFunc(producer), exchange, taskInfo)
 	})
 	require.NoError(err)
 	require.NotNil(publishedMsg)

--- a/task/runner_test.go
+++ b/task/runner_test.go
@@ -43,6 +43,7 @@ func TestSimplePublishErrorDoesNotPanic(t *testing.T) {
 		Exchange:   "uniswap",
 		Key:        "task.result.ICO.LPT",
 		Persistent: true,
+		Mandatory:  true,
 		WaitResult: true,
 		Body: &data.TaskResultEvent{
 			Base: base,

--- a/task/transcode.go
+++ b/task/transcode.go
@@ -158,7 +158,7 @@ func TaskTranscode(tctx *TaskContext) (*TaskHandlerOutput, error) {
 
 	streamName := fmt.Sprintf("vod_%s", time.Now().Format("2006-01-02T15:04:05Z07:00"))
 	profiles := []api.Profile{tctx.Params.Transcode.Profile}
-	stream, err := lapi.CreateStreamR(api.CreateStreamReq{Name: streamName, Profiles: profiles})
+	stream, err := lapi.CreateStream(api.CreateStreamReq{Name: streamName, Profiles: profiles})
 	if err != nil {
 		return nil, err
 	}
@@ -201,7 +201,7 @@ out:
 		}
 		glog.V(model.VERBOSE).Infof("Got segment seqNo=%d pts=%s dur=%s data len bytes=%d\n", seg.SeqNo, seg.Pts, seg.Duration, len(seg.Data))
 		started := time.Now()
-		transcoded, err = lapi.PushSegmentR(stream.ID, seg.SeqNo, seg.Duration, seg.Data, contentResolution)
+		transcoded, err = lapi.PushSegment(stream.ID, seg.SeqNo, seg.Duration, seg.Data, contentResolution)
 		if err != nil {
 			glog.Errorf("Segment push playbackID=%s err=%v\n", inputPlaybackID, err)
 			break


### PR DESCRIPTION
This is to make several reliability improvemenets towards the 12/16 launch milestone.

Included changes:
 - Handle 429 errors from the API and backoff task execution
 - Make our panic handling logic as resilient as possible, using a different flow for sending events
 - Update go-api-client and livepeer-data for reliabiltiy improvements (better panic handling, strong consistency for assets/tasks, etc)
 - Setup dead lettering for unprocessable messages received from Rabbit. We will need to create new queues because DLX argument is not mutable, so I've also added the "clean up old queue" logic to be used during the rollout (basically deploy, move messages from old queues to new queues, then delete empty old queues manually)
 - Publish all messages with a separate timeout from the surrounding context and also with `mandatory: true` (although later I realized that to get full benefits we need more logic in the AMQP producer)