### PR TITLE
Humanize some Catalyst errors

### DIFF
--- a/task/runner.go
+++ b/task/runner.go
@@ -475,6 +475,11 @@ func errorInfo(err error) *data.ErrorInfo {
 func humanizeCatalystError(err error) error {
 	errMsg := strings.ToLower(err.Error())
 
+	// General errors
+	if strings.Contains(errMsg, "import request") && strings.Contains(errMsg, "504 Gateway Timeout") {
+		return errors.New("file could not be imported from URL because it was not accessible")
+	}
+
 	// Livepeer pipeline errors
 	if strings.Contains(errMsg, "unsupported input pixel format") {
 		return errors.New("unsupported input pixel format, must be 'yuv420p' or 'yuvj420p'")

--- a/task/runner.go
+++ b/task/runner.go
@@ -480,6 +480,15 @@ func humanizeCatalystError(err error) error {
 		return errors.New("file could not be imported from URL because it was not accessible")
 	}
 
+	// MediaConvert pipeline errors
+	if strings.Contains(errMsg, "doesn't have video that the transcoder can consume") {
+		// TODO(yondonfu): Add link in this error message to a page with the input codec/container support matrix
+		return errors.New("invalid video file codec or container, check your input file against the input codec and container support matrix")
+	} else if strings.Contains(errMsg, "Failed probe/open") {
+		// TODO(yondonfu): Add link in this error message to a page with the input codec/container support matrix
+		return errors.New("failed to probe or open file, check your input file against the input codec and container support matrix")
+	}
+
 	// Livepeer pipeline errors
 	if strings.Contains(errMsg, "unsupported input pixel format") {
 		return errors.New("unsupported input pixel format, must be 'yuv420p' or 'yuvj420p'")


### PR DESCRIPTION
Adds humanized versions of a few additional Catalyst errors:

Internal error type: 504 gateway timeouts during file import
Humanized error: file could not be imported from URL because it was not accessible

Internal error type: Unsupported video files for MediaConvert
Humanized error: invalid video file codec or container, check your input file against the input codec and container support matrix

Internal error type: Failure to probe or open files for MediaConvert
Humanized error: failed to probe or open file, check your input file against the input codec and container support matrix

These humanized errors should help with error filtering and categorization at the Studio API task level since these humanized errors can be stored as the error message for a failed task instead of the generic "internal error processing file"