### PR TITLE
Fix 0/0 framerate handling for video tracks when probing

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/peterbourgon/ff v1.7.1
 	github.com/prometheus/client_golang v1.14.0
 	github.com/rabbitmq/amqp091-go v1.5.0
-	github.com/stretchr/testify v1.8.0
+	github.com/stretchr/testify v1.8.1
 	golang.org/x/sync v0.1.0
 	gopkg.in/vansante/go-ffprobe.v2 v2.1.1
 )
@@ -65,7 +65,7 @@ require (
 	github.com/prometheus/common v0.37.0 // indirect
 	github.com/prometheus/procfs v0.8.0 // indirect
 	github.com/rabbitmq/rabbitmq-stream-go-client v1.0.1-rc.2 // indirect
-	github.com/stretchr/objx v0.4.0 // indirect
+	github.com/stretchr/objx v0.5.0 // indirect
 	github.com/tomnomnom/linkheader v0.0.0-20180905144013-02ca5825eb80 // indirect
 	github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f // indirect
 	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect

--- a/go.sum
+++ b/go.sum
@@ -405,6 +405,8 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0 h1:M2gUjqZET1qApGOWNSnZ49BAIMX4F/1plDv3+l31EJ4=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
+github.com/stretchr/objx v0.5.0 h1:1zr/of2m5FGMsad5YfcqgdqdWrIhu+EBEJRhR1U7z/c=
+github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
@@ -414,6 +416,8 @@ github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0 h1:pSgiaMZlXftHpm5L7V1+rVB+AZJydKsMxsQBIJw4PKk=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
+github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
+github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/syndtr/goleveldb v1.0.0/go.mod h1:ZVVdQEZoIme9iO1Ch2Jdy24qqXrMMOU6lpPAyBWyWuQ=
 github.com/tomnomnom/linkheader v0.0.0-20180905144013-02ca5825eb80 h1:nrZ3ySNYwJbSpD6ce9duiP+QkD3JuLCcWkdaehUS/3Y=
 github.com/tomnomnom/linkheader v0.0.0-20180905144013-02ca5825eb80/go.mod h1:iFyPdL66DjUD96XmzVL3ZntbzcflLnznH0fr99w5VqE=

--- a/task/probe.go
+++ b/task/probe.go
@@ -3,6 +3,7 @@ package task
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"math"
 	"path"
@@ -214,6 +215,18 @@ func parseFps(framerate string) (float64, error) {
 	if err != nil {
 		return 0, fmt.Errorf("error parsing framerate denominator: %w", err)
 	}
+
+	if den == 0 {
+		// If numerator and denominator are 0 return 0.0 for the FPS
+		// 0/0 can be valid for a video track i.e. mjpeg
+		if num == 0 {
+			return 0, nil
+		}
+
+		// If only denominator is 0 then the framerate is invalid
+		return 0, errors.New("invalid framerate denominator 0")
+	}
+
 	return float64(num) / float64(den), nil
 }
 

--- a/task/probe_test.go
+++ b/task/probe_test.go
@@ -1,0 +1,51 @@
+package task
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseFps(t *testing.T) {
+	assert := assert.New(t)
+
+	// single value, invalid
+	_, err := parseFps("foobar")
+	assert.ErrorContains(err, "error parsing framerate:")
+
+	// single value
+	fps, err := parseFps("5")
+	assert.Nil(err)
+	assert.Equal(fps, 5.0)
+
+	// fraction, invalid
+	_, err = parseFps("foo/bar")
+	assert.ErrorContains(err, "error parsing framerate numerator:")
+
+	// invalid numerator
+	_, err = parseFps("foo/1")
+	assert.ErrorContains(err, "error parsing framerate numerator:")
+
+	// invalid denominator
+	_, err = parseFps("1/foo")
+	assert.ErrorContains(err, "error parsing framerate denominator:")
+
+	// 1/0
+	// -1/0
+	// 0/0
+
+	// 5/1
+	fps, err = parseFps("5/1")
+	assert.Nil(err)
+	assert.Equal(fps, 5.0)
+
+	// 1/1
+	fps, err = parseFps("1/1")
+	assert.Nil(err)
+	assert.Equal(fps, 1.0)
+
+	// 1/4
+	fps, err = parseFps("1/4")
+	assert.Nil(err)
+	assert.Equal(fps, 0.25)
+}

--- a/task/probe_test.go
+++ b/task/probe_test.go
@@ -31,8 +31,13 @@ func TestParseFps(t *testing.T) {
 	assert.ErrorContains(err, "error parsing framerate denominator:")
 
 	// 1/0
-	// -1/0
+	_, err = parseFps("1/0")
+	assert.ErrorContains(err, "invalid framerate denominator 0")
+
 	// 0/0
+	fps, err = parseFps("0/0")
+	assert.Nil(err)
+	assert.Equal(fps, 0.0)
 
 	// 5/1
 	fps, err = parseFps("5/1")


### PR DESCRIPTION
This PR fixes a bug where the `parseFps()` function would return NaN for an input framerate of 0/0. The NaN value would be set as the value for a track's `FPS` field [here](https://github.com/livepeer/task-runner/blob/59c241c05d9541c34906a4e0786313cb26339d31/task/probe.go#L179). The track is nested in the larger [api.AssetSpec](https://github.com/livepeer/go-api-client/blob/c3675c55eed57d6d916f7db498af0956733e00ad/api.go#L329) struct which is marshalled in [saveMetadataFile()](https://github.com/livepeer/task-runner/blob/6853b65ac1ba193e59875e6a04383d73d0744972/task/import.go#L187) which is called during upload task execution after [task-runner receives a callback](https://github.com/livepeer/task-runner/blob/6853b65ac1ba193e59875e6a04383d73d0744972/task/upload.go#L321) from Catalyst in order to "complement" Catalyst which involves copying the source file into a bucket and also probing the file. The NaN value nested in the `api.AssetSpec` struct results in the following error in the call to `saveMetadataFile()`:

```
error marshaling file metadat: json: unsupported value: NaN
```

I observed this error for a file containing a mjpeg video track with the avg framerate set to 0/0. 