### PR TITLE
Humanize no video codec error

### DIFF
--- a/task/runner.go
+++ b/task/runner.go
@@ -520,6 +520,7 @@ func humanizeCatalystError(err error) error {
 		// Keeping it simple for now and returning errInvalidVideo for this
 		// But, should there be a separate humanized error for this?
 		"readpacketdata file read failed - end of file hit",
+		"no video track found in file",
 	}
 
 	// MediaConvert pipeline errors

--- a/task/runner.go
+++ b/task/runner.go
@@ -508,7 +508,7 @@ func humanizeCatalystError(err error) error {
 
 	if strings.Contains(errMsg, "upload error") && strings.Contains(errMsg, "failed to write file") {
 		// Handle error reading source when copying
-		if strings.Contains(errMsg, "unexpected EOF") {
+		if strings.Contains(errMsg, "unexpected eof") {
 			return errFileInaccessible
 		}
 	}

--- a/task/runner_test.go
+++ b/task/runner_test.go
@@ -41,6 +41,9 @@ func TestHumanizeError(t *testing.T) {
 
 	err = NewCatalystError("foobar Failed probe/open: foobar", false)
 	assert.Error(humanizeError(err), errProbe)
+
+	err = NewCatalystError("no video track found in file", false)
+	assert.Error(humanizeError(err), errInvalidVideo)
 }
 
 func TestSimplePublishErrorDoesNotPanic(t *testing.T) {

--- a/task/runner_test.go
+++ b/task/runner_test.go
@@ -16,34 +16,34 @@ func TestHumanizeError(t *testing.T) {
 
 	// Catalyst errors
 	err := NewCatalystError("download error import request 504 Gateway Timeout", false)
-	assert.Error(humanizeError(err), errFileInaccessible)
+	assert.ErrorContains(humanizeError(err), errFileInaccessible.Error())
 
 	err = NewCatalystError("download error import request 404 Not Found", false)
-	assert.Error(humanizeError(err), errFileInaccessible)
+	assert.ErrorContains(humanizeError(err), errFileInaccessible.Error())
 
 	err = NewCatalystError("download error import request giving up after", false)
-	assert.Error(humanizeError(err), errFileInaccessible)
+	assert.ErrorContains(humanizeError(err), errFileInaccessible.Error())
 
 	err = NewCatalystError("upload error: failed to write file foobar to foobar: unexpected EOF", false)
-	assert.Error(humanizeError(err), errFileInaccessible)
+	assert.ErrorContains(humanizeError(err), errFileInaccessible.Error())
 
 	err = NewCatalystError("foobar doesn't have video that the transcoder can consume foobar", false)
-	assert.Error(humanizeError(err), errInvalidVideo)
+	assert.ErrorContains(humanizeError(err), errInvalidVideo.Error())
 
 	err = NewCatalystError("foobar is not a supported input video codec foobar", false)
-	assert.Error(humanizeError(err), errInvalidVideo)
+	assert.ErrorContains(humanizeError(err), errInvalidVideo.Error())
 
 	err = NewCatalystError("foobar is not a supported input audio codec foobar", false)
-	assert.Error(humanizeError(err), errInvalidVideo)
+	assert.ErrorContains(humanizeError(err), errInvalidVideo.Error())
 
 	err = NewCatalystError("Demuxer: [ReadPacketData File read failed - end of file hit at length [5242880]. Is file truncated?]", false)
-	assert.Error(humanizeError(err), errInvalidVideo)
+	assert.ErrorContains(humanizeError(err), errInvalidVideo.Error())
 
 	err = NewCatalystError("foobar Failed probe/open: foobar", false)
-	assert.Error(humanizeError(err), errProbe)
+	assert.ErrorContains(humanizeError(err), errProbe.Error())
 
 	err = NewCatalystError("no video track found in file", false)
-	assert.Error(humanizeError(err), errInvalidVideo)
+	assert.ErrorContains(humanizeError(err), errInvalidVideo.Error())
 }
 
 func TestSimplePublishErrorDoesNotPanic(t *testing.T) {


### PR DESCRIPTION
Translate "no video track found in file" errors to `errInvalidVideo`