### PR TITLE
task: Allow decrypting input files with AESCBC

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/livepeer/task-runner
 go 1.19
 
 require (
+	github.com/d1str0/pkcs7 v0.0.0-20200424205038-d65c16a5759a
 	github.com/golang/glog v1.0.0
 	github.com/julienschmidt/httprouter v1.3.0
 	github.com/livepeer/catalyst-api v0.0.13-0.20230216132322-8b4f260542df

--- a/go.sum
+++ b/go.sum
@@ -57,6 +57,8 @@ github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDk
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/cskr/pubsub v1.0.2 h1:vlOzMhl6PFn60gRlTQQsIfVwaPB/B/8MziK8FhEPt/0=
+github.com/d1str0/pkcs7 v0.0.0-20200424205038-d65c16a5759a h1:NtjeEx9EbZH6iM4BCho0yBMr7VjDu8MagoWU+dBKGpo=
+github.com/d1str0/pkcs7 v0.0.0-20200424205038-d65c16a5759a/go.mod h1:g4F5sZT1Eult6KqY9vzZ6Uf9H5FwP3WsHx8NX3UNfN8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/task/encryption/decrypt.go
+++ b/task/encryption/decrypt.go
@@ -1,0 +1,62 @@
+package encryption
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"encoding/hex"
+	"fmt"
+	"io"
+)
+
+func DecryptAES256CBCReader(reader io.ReadCloser, keyb16 string) (io.ReadCloser, error) {
+	key, err := hex.DecodeString(keyb16)
+	if err != nil {
+		return nil, fmt.Errorf("error decoding base16 key: %w", err)
+	}
+
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return nil, fmt.Errorf("error creating cipher: %w", err)
+	}
+
+	iv := make([]byte, aes.BlockSize)
+	if _, err := reader.Read(iv); err != nil {
+		return nil, fmt.Errorf("error reading iv from input: %w", err)
+	}
+
+	stream := cipher.NewCBCDecrypter(block, iv)
+	pipeReader, pipeWriter := io.Pipe()
+
+	go func() {
+		defer reader.Close()
+		defer pipeWriter.Close()
+		defer func() {
+			if r := recover(); r != nil {
+				pipeWriter.CloseWithError(fmt.Errorf("panic: %v", r))
+			}
+		}()
+
+		buffer := make([]byte, 256*aes.BlockSize)
+		for {
+			n, err := io.ReadFull(reader, buffer)
+			if n == 0 {
+				break
+			} else if err != nil && err != io.ErrUnexpectedEOF {
+				pipeWriter.CloseWithError(err)
+				return
+			}
+
+			// padding only happens on the last block and we just ignore the extra bytes
+			padSize := n % aes.BlockSize
+			paddedSize := n + padSize
+			stream.CryptBlocks(buffer[:paddedSize], buffer[:paddedSize])
+
+			if _, err := pipeWriter.Write(buffer[:n]); err != nil {
+				pipeWriter.CloseWithError(err)
+				return
+			}
+		}
+	}()
+
+	return pipeReader, nil
+}

--- a/task/encryption/decrypt.go
+++ b/task/encryption/decrypt.go
@@ -1,11 +1,14 @@
 package encryption
 
 import (
+	"bufio"
 	"crypto/aes"
 	"crypto/cipher"
 	"encoding/hex"
 	"fmt"
 	"io"
+
+	"github.com/d1str0/pkcs7"
 )
 
 func DecryptAES256CBCReader(reader io.ReadCloser, keyb16 string) (io.ReadCloser, error) {
@@ -24,7 +27,7 @@ func DecryptAES256CBCReader(reader io.ReadCloser, keyb16 string) (io.ReadCloser,
 		return nil, fmt.Errorf("error reading iv from input: %w", err)
 	}
 
-	stream := cipher.NewCBCDecrypter(block, iv)
+	decrypter := cipher.NewCBCDecrypter(block, iv)
 	pipeReader, pipeWriter := io.Pipe()
 
 	go func() {
@@ -37,21 +40,39 @@ func DecryptAES256CBCReader(reader io.ReadCloser, keyb16 string) (io.ReadCloser,
 		}()
 
 		buffer := make([]byte, 256*aes.BlockSize)
+		bufReader := bufio.NewReaderSize(reader, 2*len(buffer))
 		for {
-			n, err := io.ReadFull(reader, buffer)
+			n, err := io.ReadFull(bufReader, buffer)
 			if n == 0 || err == io.EOF {
 				break
 			} else if err != nil && err != io.ErrUnexpectedEOF {
+				// unexpected EOF is returned when input ends before the buffer size
+				pipeWriter.CloseWithError(err)
+				return
+			} else if n%aes.BlockSize != 0 {
+				// this can only ever happen on the last chunk
+				err := fmt.Errorf("input is not a multiple of AES block size. must be padded with PKCS#7")
 				pipeWriter.CloseWithError(err)
 				return
 			}
 
-			// padding only happens on the last block and we just ignore the extra bytes
-			padSize := (aes.BlockSize - (n % aes.BlockSize)) % aes.BlockSize
-			paddedSize := n + padSize
-			stream.CryptBlocks(buffer[:paddedSize], buffer[:paddedSize])
+			chunk := buffer[:n]
+			decrypter.CryptBlocks(chunk, chunk)
 
-			if _, err := pipeWriter.Write(buffer[:n]); err != nil {
+			if _, peekErr := bufReader.Peek(1); peekErr == io.EOF {
+				// this means we're on the last chunk, so handle padding
+				lastBlock := chunk[len(chunk)-aes.BlockSize:]
+				unpadded, err := pkcs7.Unpad(lastBlock)
+				if err != nil {
+					pipeWriter.CloseWithError(fmt.Errorf("bad input PKCS#7 padding: %w", err))
+					return
+				}
+
+				padSize := len(lastBlock) - len(unpadded)
+				chunk = chunk[:len(chunk)-padSize]
+			}
+
+			if _, err := pipeWriter.Write(chunk); err != nil {
 				pipeWriter.CloseWithError(err)
 				return
 			}

--- a/task/encryption/decrypt.go
+++ b/task/encryption/decrypt.go
@@ -22,8 +22,8 @@ func DecryptAES256CBCReader(reader io.ReadCloser, keyb16 string) (io.ReadCloser,
 		return nil, fmt.Errorf("error creating cipher: %w", err)
 	}
 
-	iv := make([]byte, aes.BlockSize)
-	if _, err := reader.Read(iv); err != nil {
+	iv := make([]byte, block.BlockSize())
+	if _, err := io.ReadFull(reader, iv); err != nil {
 		return nil, fmt.Errorf("error reading iv from input: %w", err)
 	}
 

--- a/task/encryption/decrypt.go
+++ b/task/encryption/decrypt.go
@@ -39,7 +39,7 @@ func DecryptAES256CBCReader(reader io.ReadCloser, keyb16 string) (io.ReadCloser,
 		buffer := make([]byte, 256*aes.BlockSize)
 		for {
 			n, err := io.ReadFull(reader, buffer)
-			if n == 0 {
+			if n == 0 || err == io.EOF {
 				break
 			} else if err != nil && err != io.ErrUnexpectedEOF {
 				pipeWriter.CloseWithError(err)

--- a/task/encryption/decrypt.go
+++ b/task/encryption/decrypt.go
@@ -47,7 +47,7 @@ func DecryptAES256CBCReader(reader io.ReadCloser, keyb16 string) (io.ReadCloser,
 			}
 
 			// padding only happens on the last block and we just ignore the extra bytes
-			padSize := n % aes.BlockSize
+			padSize := (aes.BlockSize - (n % aes.BlockSize)) % aes.BlockSize
 			paddedSize := n + padSize
 			stream.CryptBlocks(buffer[:paddedSize], buffer[:paddedSize])
 

--- a/task/import.go
+++ b/task/import.go
@@ -18,7 +18,7 @@ import (
 	"github.com/livepeer/go-api-client/logs"
 	"github.com/livepeer/go-tools/drivers"
 	"github.com/livepeer/livepeer-data/pkg/data"
-	"github.com/livepeer/task-runner/task/encryption"
+	"github.com/livepeer/task-runner/webcrypto"
 )
 
 const IPFS_PREFIX = "ipfs://"
@@ -102,7 +102,7 @@ func getFile(ctx context.Context, osSess drivers.OSSession, cfg ImportTaskConfig
 	switch params.Encryption.Algorithm {
 	case "", "aes-256-cbc":
 		glog.V(logs.VVERBOSE).Infof("Decrypting file with key file=%s keyHash=%x", params.URL, sha256.Sum256([]byte(params.Encryption.Key)))
-		decrypted, err := encryption.DecryptAES256CBCReader(content, params.Encryption.Key)
+		decrypted, err := webcrypto.DecryptAESCBC(content, params.Encryption.Key)
 		if err != nil {
 			content.Close()
 			return "", 0, nil, fmt.Errorf("failed to decrypt input file: %w", err)

--- a/task/import.go
+++ b/task/import.go
@@ -101,16 +101,10 @@ func getFile(ctx context.Context, osSess drivers.OSSession, cfg ImportTaskConfig
 
 	switch params.Encryption.Algorithm {
 	case "", "aes-256-cbc":
-		glog.V(logs.VERBOSE).Infof("Reading file for decryption file=%s", params.URL)
-		_, _, encrypted, err := getFile(ctx, osSess, cfg, params)
-		if err != nil {
-			return "", 0, nil, fmt.Errorf("failed to get input file: %w", err)
-		}
-
 		glog.V(logs.VVERBOSE).Infof("Decrypting file with key file=%s keyHash=%x", params.URL, sha256.Sum256([]byte(params.Encryption.Key)))
-		decrypted, err := encryption.DecryptAES256CBCReader(encrypted, params.Encryption.Key)
+		decrypted, err := encryption.DecryptAES256CBCReader(content, params.Encryption.Key)
 		if err != nil {
-			encrypted.Close()
+			content.Close()
 			return "", 0, nil, fmt.Errorf("failed to decrypt input file: %w", err)
 		}
 

--- a/task/import.go
+++ b/task/import.go
@@ -99,8 +99,8 @@ func getFile(ctx context.Context, osSess drivers.OSSession, cfg ImportTaskConfig
 		return
 	}
 
-	switch params.Encryption.Algorithm {
-	case "", "aes-256-cbc":
+	switch strings.ToLower(params.Encryption.Algorithm) {
+	case "", "aes-cbc":
 		glog.V(logs.VVERBOSE).Infof("Decrypting file with key file=%s keyHash=%x", params.URL, sha256.Sum256([]byte(params.Encryption.Key)))
 		decrypted, err := webcrypto.DecryptAESCBC(content, params.Encryption.Key)
 		if err != nil {

--- a/task/upload.go
+++ b/task/upload.go
@@ -1,7 +1,6 @@
 package task
 
 import (
-	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -16,7 +15,6 @@ import (
 	"github.com/livepeer/catalyst-api/pipeline"
 	"github.com/livepeer/catalyst-api/video"
 	"github.com/livepeer/go-api-client"
-	"github.com/livepeer/go-tools/drivers"
 	"github.com/livepeer/livepeer-data/pkg/data"
 	"github.com/livepeer/task-runner/clients"
 )
@@ -125,7 +123,7 @@ func handleUploadVOD(p handleUploadVODParams) (*TaskHandlerOutput, error) {
 
 func TaskUpload(tctx *TaskContext) (*TaskHandlerOutput, error) {
 	params := *tctx.Task.Params.Upload
-	inUrl, err := getFileUrlForUploadTask(tctx, tctx.outputOS, tctx.OutputOSObj, tctx.ImportTaskConfig, params, tctx.OutputAsset.PlaybackID)
+	inUrl, err := getFileUrlForUploadTask(tctx.OutputOSObj, params)
 	if err != nil {
 		return nil, fmt.Errorf("error building file URL: %w", err)
 	}
@@ -224,7 +222,7 @@ func parseUrlToBaseAndPath(URL string) (string, string, error) {
 	return baseUrl, p, nil
 }
 
-func getFileUrlForUploadTask(ctx context.Context, osSess drivers.OSSession, os *api.ObjectStore, cfg ImportTaskConfig, params api.UploadTaskParams, playbackID string) (string, error) {
+func getFileUrlForUploadTask(os *api.ObjectStore, params api.UploadTaskParams) (string, error) {
 	osPublicURL, err := url.Parse(os.PublicURL)
 	if err != nil {
 		return "", fmt.Errorf("error parsing object store public URL: %w", err)

--- a/task/upload.go
+++ b/task/upload.go
@@ -56,10 +56,12 @@ func handleUploadVOD(p handleUploadVODParams) (*TaskHandlerOutput, error) {
 	)
 	switch step {
 	case "":
-		var err error
-		inUrl, err = decryptInputFile(tctx, inUrl)
-		if err != nil {
-			return nil, fmt.Errorf("error decrypting input file: %w", err)
+		if uploadParams := tctx.Params.Upload; uploadParams != nil {
+			var err error
+			inUrl, err = decryptInputFile(tctx, inUrl, *uploadParams)
+			if err != nil {
+				return nil, fmt.Errorf("error decrypting input file: %w", err)
+			}
 		}
 		fallthrough
 	case "rateLimitBackoff":
@@ -232,9 +234,8 @@ func getFileUrlForUploadTask(ctx context.Context, osSess drivers.OSSession, os *
 	return params.URL, nil
 }
 
-func decryptInputFile(tctx *TaskContext, fileUrl string) (string, error) {
+func decryptInputFile(tctx *TaskContext, fileUrl string, params api.UploadTaskParams) (string, error) {
 	var (
-		params     = *tctx.Task.Params.Upload
 		osSess     = tctx.outputOS
 		os         = tctx.OutputOSObj
 		cfg        = tctx.ImportTaskConfig

--- a/task/upload.go
+++ b/task/upload.go
@@ -223,12 +223,12 @@ func parseUrlToBaseAndPath(URL string) (string, string, error) {
 }
 
 func getFileUrlForUploadTask(os *api.ObjectStore, params api.UploadTaskParams) (string, error) {
-	osPublicURL, err := url.Parse(os.PublicURL)
-	if err != nil {
-		return "", fmt.Errorf("error parsing object store public URL: %w", err)
-	}
-	if params.UploadedObjectKey != "" {
-		return osPublicURL.JoinPath(params.UploadedObjectKey).String(), nil
+	if key := params.UploadedObjectKey; key != "" {
+		u, err := url.Parse(os.PublicURL)
+		if err != nil {
+			return "", err
+		}
+		return u.JoinPath(key).String(), nil
 	}
 	return params.URL, nil
 }

--- a/task/upload.go
+++ b/task/upload.go
@@ -226,12 +226,14 @@ func getFileUrlForUploadTask(ctx context.Context, osSess drivers.OSSession, os *
 		return params.URL, nil
 	}
 
+	glog.Infof("Downloading file=%s from object store", params.URL)
 	_, _, content, err := getFile(ctx, osSess, cfg, params)
 	if err != nil {
 		return "", fmt.Errorf("failed to get input file: %w", err)
 	}
 	defer content.Close()
 
+	glog.Infof("Uploading decrypted file=%s to object store", params.URL)
 	fullPath := videoFileName(playbackID)
 	fileUrl, err := osSess.SaveData(ctx, fullPath, content, nil, fileUploadTimeout)
 	if err != nil {

--- a/task/upload.go
+++ b/task/upload.go
@@ -56,6 +56,7 @@ func handleUploadVOD(p handleUploadVODParams) (*TaskHandlerOutput, error) {
 	)
 	switch step {
 	case "":
+		// TODO: Move this input decryption logic to catalyst
 		if uploadParams := tctx.Params.Upload; uploadParams != nil {
 			var err error
 			inUrl, err = decryptInputFile(tctx, inUrl, *uploadParams)

--- a/webcrypto/aes.go
+++ b/webcrypto/aes.go
@@ -66,11 +66,11 @@ func decryptReaderTo(readerRaw io.Reader, writer io.Writer, decrypter cipher.Blo
 
 	for {
 		n, err := io.ReadFull(reader, buffer)
-		if n == 0 || err == io.EOF {
-			break
-		} else if err != nil && err != io.ErrUnexpectedEOF {
+		if err != nil && err != io.ErrUnexpectedEOF && err != io.EOF {
 			// unexpected EOF is returned when input ends before the buffer size
 			return err
+		} else if n == 0 {
+			break
 		}
 
 		chunk := buffer[:n]

--- a/webcrypto/aes.go
+++ b/webcrypto/aes.go
@@ -1,4 +1,4 @@
-package encryption
+package webcrypto
 
 import (
 	"bufio"
@@ -11,7 +11,7 @@ import (
 	"github.com/d1str0/pkcs7"
 )
 
-func DecryptAES256CBCReader(reader io.ReadCloser, keyb16 string) (io.ReadCloser, error) {
+func DecryptAESCBC(reader io.ReadCloser, keyb16 string) (io.ReadCloser, error) {
 	key, err := hex.DecodeString(keyb16)
 	if err != nil {
 		return nil, fmt.Errorf("error decoding base16 key: %w", err)


### PR DESCRIPTION
This adds on top of https://github.com/livepeer/studio/pull/1645 to decrypt input files with
AES-256-CBC if a key was provided. 

Notice that this should ideally be done in Catalyst for a real implementation, but made this
quickly in order to create an experiment. The file is decrypted and copied to S3 instead of 
sent raw to Catalyst.

The experiment name is `vod-encrypted-input` and is checked by the API here: https://github.com/livepeer/livepeer-com/blob/579b4835ebfc15ca4700ac30b86a45159a4ddd1f/packages/api/src/controllers/asset.ts#L579