### PR TITLE
task: Fix checkCatalyst loop when the queues are long

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/golang/glog v1.0.0
 	github.com/julienschmidt/httprouter v1.3.0
 	github.com/livepeer/catalyst-api v0.0.13-0.20230209204355-762c5216cdd4
-	github.com/livepeer/go-api-client v0.4.2-0.20230119202619-e1212b58032b
+	github.com/livepeer/go-api-client v0.4.3-0.20230213162246-885c0d8ba335
 	github.com/livepeer/go-tools v0.2.4
 	github.com/livepeer/joy4 v0.1.2-0.20220210094601-95e4d28f5f07
 	github.com/livepeer/livepeer-data v0.6.4

--- a/go.sum
+++ b/go.sum
@@ -293,10 +293,8 @@ github.com/libp2p/go-netroute v0.2.0 h1:0FpsbsvuSnAhXFnCY0VLFbJOzaK0VnP0r1QT/o4n
 github.com/libp2p/go-openssl v0.1.0 h1:LBkKEcUv6vtZIQLVTegAil8jbNpJErQ9AnT+bWV+Ooo=
 github.com/livepeer/catalyst-api v0.0.13-0.20230209204355-762c5216cdd4 h1:TdHFpWLDgn+yUQmsKjJs73l7cKNPBnwr3YRU1Rv0/cg=
 github.com/livepeer/catalyst-api v0.0.13-0.20230209204355-762c5216cdd4/go.mod h1:CCH74xkS+33BdhjX5FqMtctnfNGXfJphpb+LYnmEAk0=
-github.com/livepeer/go-api-client v0.4.2-0.20230119202619-e1212b58032b h1:rUdhUoG+PLi5jpA72fDQXv4Corkf8BEVybduuup3Q28=
-github.com/livepeer/go-api-client v0.4.2-0.20230119202619-e1212b58032b/go.mod h1:Jdb+RI7JyzEZOHd1GUuKofwFDKMO/btTa80SdpUpYQw=
-github.com/livepeer/go-tools v0.2.4-0.20230209204125-83366ffbcdb3 h1:+ZknCLY+hGYG7erLdiTZ4k2hag+3EFq7jTvqhsXcXSk=
-github.com/livepeer/go-tools v0.2.4-0.20230209204125-83366ffbcdb3/go.mod h1:/aZ+20XYLdeebFA3CrQTkHUf7DmiGBzh6Bs8JkbelUA=
+github.com/livepeer/go-api-client v0.4.3-0.20230213162246-885c0d8ba335 h1:TAweH1OiD/f6VNvJf54YpHFcntaRlVnnkPJH1qjyILA=
+github.com/livepeer/go-api-client v0.4.3-0.20230213162246-885c0d8ba335/go.mod h1:Jdb+RI7JyzEZOHd1GUuKofwFDKMO/btTa80SdpUpYQw=
 github.com/livepeer/go-tools v0.2.4 h1:H1nByTy9U9XBgnEQCEA5WdjbhPEJXXqSyPBXEr+2VHQ=
 github.com/livepeer/go-tools v0.2.4/go.mod h1:/aZ+20XYLdeebFA3CrQTkHUf7DmiGBzh6Bs8JkbelUA=
 github.com/livepeer/joy4 v0.1.2-0.20220210094601-95e4d28f5f07 h1:ISkFQYYDgfnM6Go+VyemF66DKFc8kNoI9SwMv7GC9sM=

--- a/task/runner.go
+++ b/task/runner.go
@@ -376,6 +376,10 @@ func (r *runner) HandleCatalysis(ctx context.Context, taskId, nextStep, attemptI
 	progress := 0.9 * callback.CompletionRatio
 	progress = math.Round(progress*1000) / 1000
 	step := "catalyst_" + strings.ToLower(callback.Status.String())
+	if callback.Status == catalystClients.TranscodeStatusCompleted {
+		step = nextStep
+	}
+
 	if shouldReportProgressTask(progress, step, task) {
 		err = r.lapi.UpdateTaskStatus(task.ID, api.TaskPhaseRunning, progress, step)
 		if err != nil {

--- a/task/runner.go
+++ b/task/runner.go
@@ -292,7 +292,7 @@ func (r *runner) handleTask(ctx context.Context, taskInfo data.TaskInfo) (out *T
 			return nil, errors.New("task has already been started before")
 		}
 
-		err = r.lapi.UpdateTaskStatus(taskID, api.TaskPhaseRunning, 0)
+		err = r.lapi.UpdateTaskStatus(taskID, api.TaskPhaseRunning, 0, "")
 		if err == api.ErrRateLimited {
 			glog.Warningf("Task execution rate limited type=%q id=%s userID=%s", taskType, taskID, taskCtx.UserID)
 			return nil, r.delayTaskStep(ctx, taskID, taskCtx.Step, taskCtx.StepInput)
@@ -332,7 +332,7 @@ func (r *runner) buildTaskContext(ctx context.Context, info data.TaskInfo) (*Tas
 	if err != nil {
 		return nil, err
 	}
-	progress := NewProgressReporter(ctx, r.lapi, task.ID)
+	progress := NewProgressReporter(ctx, r.lapi, task.ID, info.Step)
 	return &TaskContext{ctx, r, info, task, progress, inputAsset, outputAsset, inputOSObj, outputOSObj, inputOS, outputOS}, nil
 }
 
@@ -375,9 +375,9 @@ func (r *runner) HandleCatalysis(ctx context.Context, taskId, nextStep, attemptI
 
 	progress := 0.9 * callback.CompletionRatio
 	progress = math.Round(progress*1000) / 1000
-	currProgress, taskUpdatedAt := task.Status.Progress, data.NewUnixMillisTime(task.Status.UpdatedAt)
-	if shouldReportProgress(progress, currProgress, task.ID, taskUpdatedAt.Time) {
-		err = r.lapi.UpdateTaskStatus(task.ID, api.TaskPhaseRunning, progress)
+	step := "catalyst_" + strings.ToLower(callback.Status.String())
+	if shouldReportProgressTask(progress, step, task) {
+		err = r.lapi.UpdateTaskStatus(task.ID, api.TaskPhaseRunning, progress, step)
 		if err != nil {
 			glog.Warningf("Failed to update task progress. taskID=%s err=%v", task.ID, err)
 		}

--- a/task/upload.go
+++ b/task/upload.go
@@ -81,7 +81,9 @@ func handleUploadVOD(p handleUploadVODParams) (*TaskHandlerOutput, error) {
 		return ContinueAsync, nil
 	case "checkCatalyst":
 		task := tctx.Task
-		if task.Status.Phase != api.TaskPhaseRunning {
+		if task.Status.Phase != api.TaskPhaseRunning || task.Status.Step == "finalize" {
+			// Task has already progressed to another phase or step. To stop the loop
+			// of `checkCatalyst` we "continue" without having scheduled another msg.
 			return ContinueAsync, nil
 		}
 		updatedAt := data.NewUnixMillisTime(task.Status.UpdatedAt)


### PR DESCRIPTION
A current bug that is happening now: 
 - catalyst finishes processing a task
 - sends a final callback to task runner
 - task runner enqueues that success so it finalizes the processing with the appropriate load balancing
 - if the queues are long, this message might end up staying in the queue for a couple minutes
 - during that time, there will be no updated to the `updatedAt` of the task, as callbacks have stopped
 - when the `checkCatalyst` loop finally gets to it, it will see a task that has had no updates for minutes-long, treat it as lost and mark it as errored on the API
 - error only gets worse cause the API will then retry the task which has the same error again

This fixes it by improving the exit condition of the `checkCatalyst` step. Instead of only finishing it once
the task has stoped `running`, we will now update the task `step` on the API and make sure to stop the
`checkCatalyst` loop as soon as the task gets to the `finalize` step. We make sure to update the step
from the catalyst callback handler already, so it happens early and stops the `checkCatalyst` loop, not
only when the finalization event gets processed.

Fixes STU-29