### PR TITLE
runner: humanize ffprobe errors

### DIFF
--- a/task/runner.go
+++ b/task/runner.go
@@ -36,7 +36,6 @@ var (
 	errInvalidVideo = UnretriableError{errors.New("invalid video file codec or container, check your input file against the input codec and container support matrix")}
 	// TODO(yondonfu): Add link in this error message to a page with the input codec/container support matrix
 	errProbe   = UnretriableError{errors.New("failed to probe or open file, check your input file against the input codec and container support matrix")}
-	errFFProbe = errors.New("error probing input file")
 )
 
 var (
@@ -543,7 +542,7 @@ func humanizeCatalystError(err error) error {
 		}
 	}
 	if strings.Contains(errMsg, "error running ffprobe") && strings.Contains(errMsg, "exit status 1") {
-		return errFFProbe
+		return errInvalidVideo 
 	}
 	if strings.Contains(errMsg, "failed probe/open") {
 		return errProbe

--- a/task/runner_test.go
+++ b/task/runner_test.go
@@ -55,7 +55,7 @@ func TestHumanizeError(t *testing.T) {
 	assert.ErrorIs(humanizeError(err), errFileInaccessible)
 
 	err = NewCatalystError("external transcoder error: error probing MP4 input file from S3: error running ffprobe [] exit status 1", false)
-	assert.ErrorIs(humanizeError(err), errFFProbe)
+	assert.ErrorIs(humanizeError(err), errInvalidVideo)
 
 	err = NewCatalystError("external transcoder error: zero bytes found for source: file:///dev/null", false)
 	assert.ErrorIs(humanizeError(err), errInvalidVideo)


### PR DESCRIPTION
A close inspection of ffprobe errors now indicates almost all ffprobe failures are related to invalid input.