### PR TITLE
task/import: Make probe non-strict for recordings import

### DIFF
--- a/task/import.go
+++ b/task/import.go
@@ -53,7 +53,8 @@ func TaskImport(tctx *TaskContext) (*TaskHandlerOutput, error) {
 
 	// Probe metadata from the source file and save it to object store.
 	input = tctx.Progress.TrackReader(sourceFile, size, 0.11)
-	metadata, err := Probe(ctx, tctx.OutputAsset.ID, filename, input, true)
+	isRecording := tctx.Params.Import.RecordedSessionID != ""
+	metadata, err := Probe(ctx, tctx.OutputAsset.ID, filename, input, !isRecording)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
We've been getting errors turning recordings with no audio into assets. This shouldn't
be really a problem for recordings since all we do is download the muxed mp4s and save
them on the object store. They can have no audio without problems (we only needed to
require audio for the oold `joy4` workflow).