### PR TITLE
task/runner: Add metrics on task latency and result

### DIFF
--- a/task/runner.go
+++ b/task/runner.go
@@ -587,12 +587,14 @@ func humanizeCatalystError(err error) error {
 
 	// Livepeer pipeline errors
 	if strings.Contains(errMsg, "unsupported input pixel format") {
-		return errors.New("unsupported input pixel format, must be 'yuv420p' or 'yuvj420p'")
-	} else if strings.Contains(errMsg, "Unsupported video input") {
-		// TODO(yondonfu): This check probably does not work because the error message will be lowercased
-		return errors.New("unsupported file format")
+		return UnretriableError{errors.New("unsupported input pixel format, must be 'yuv420p' or 'yuvj420p'")}
+	} else if strings.Contains(errMsg, "unsupported video input") {
+		return UnretriableError{errors.New("unsupported file format")}
 	}
 
+	if IsUnretriable(err) {
+		return UnretriableError{errInternalProcessingError}
+	}
 	return errInternalProcessingError
 }
 

--- a/task/runner.go
+++ b/task/runner.go
@@ -606,8 +606,6 @@ func humanizeCatalystError(err error) error {
 	// Livepeer pipeline errors
 	if strings.Contains(errMsg, "unsupported input pixel format") {
 		return UnretriableError{errors.New("unsupported input pixel format, must be 'yuv420p' or 'yuvj420p'")}
-	} else if strings.Contains(errMsg, "unsupported video input") {
-		return UnretriableError{errors.New("unsupported file format")}
 	}
 
 	if IsUnretriable(err) {


### PR DESCRIPTION
We've created some alerts that use catalyst metrics to alert us. This is very limited
and has lead to a lot of noise in pagerduty since we have limited information in 
catalyst about how the errors should be handled, like when are they user errors.

With this, we'll be able to create a more e2e alert based on the actual error returned
by task runner, also filtering unretriable errors which are generally bad inputs which we
should not be alerted for.

Also created a metric for the latency executing tasks which will be good for monitoring.