### PR TITLE
Tweak the error matching for probe errors

### DIFF
--- a/task/runner.go
+++ b/task/runner.go
@@ -596,11 +596,11 @@ func humanizeCatalystError(err error) error {
 			return errInvalidVideo
 		}
 	}
-	if strings.Contains(errMsg, "error running ffprobe") && strings.Contains(errMsg, "exit status 1") {
-		return errInvalidVideo
-	}
 	if strings.Contains(errMsg, "failed probe/open") {
 		return errProbe
+	}
+	if strings.Contains(errMsg, "error probing") {
+		return errInvalidVideo
 	}
 
 	// Livepeer pipeline errors


### PR DESCRIPTION
The previous string wasn't matching every case, it was also a specific error message coming from the library we are using so subject to change.