### PR TITLE
Handle the case where an asset is deleted by the user part way through processing

### DIFF
--- a/task/errors.go
+++ b/task/errors.go
@@ -7,6 +7,8 @@ import (
 	api "github.com/livepeer/go-api-client"
 )
 
+var assetNotFound = errors.New("asset not found")
+
 type UnretriableError struct{ error }
 
 func (e UnretriableError) Error() string { return e.error.Error() }

--- a/task/runner.go
+++ b/task/runner.go
@@ -300,7 +300,8 @@ func (r *runner) handleTask(ctx context.Context, taskInfo data.TaskInfo) (out *T
 	taskCtx, err := r.buildTaskContext(ctx, taskInfo)
 	if err != nil {
 		if errors.Is(err, assetNotFound) {
-			return nil, UnretriableError{fmt.Errorf("task cancelled, asset not found. taskID=%s", taskInfo.ID)}
+			glog.Infof("task cancelled, asset has been deleted. taskID=%s", taskInfo.ID)
+			return nil, UnretriableError{errors.New("task cancelled, asset has been deleted")}
 		}
 		return nil, fmt.Errorf("error building task context: %w", err)
 	}

--- a/task/runner.go
+++ b/task/runner.go
@@ -300,7 +300,7 @@ func (r *runner) handleTask(ctx context.Context, taskInfo data.TaskInfo) (out *T
 	taskCtx, err := r.buildTaskContext(ctx, taskInfo)
 	if err != nil {
 		if errors.Is(err, assetNotFound) {
-			return nil, UnretriableError{errors.New("task cancelled, asset not found")}
+			return nil, UnretriableError{fmt.Errorf("task cancelled, asset not found. taskID=%s", taskInfo.ID)}
 		}
 		return nil, fmt.Errorf("error building task context: %w", err)
 	}

--- a/task/runner_test.go
+++ b/task/runner_test.go
@@ -148,6 +148,6 @@ func TestHandleTaskAssetNotFound(t *testing.T) {
 			Server: apiServer.URL,
 		}),
 	}
-	_, err := runner.handleTask(context.Background(), data.TaskInfo{})
-	require.EqualError(t, err, "task cancelled, asset not found")
+	_, err := runner.handleTask(context.Background(), data.TaskInfo{ID: "task"})
+	require.EqualError(t, err, "task cancelled, asset not found. taskID=task")
 }

--- a/task/runner_test.go
+++ b/task/runner_test.go
@@ -149,5 +149,5 @@ func TestHandleTaskAssetNotFound(t *testing.T) {
 		}),
 	}
 	_, err := runner.handleTask(context.Background(), data.TaskInfo{ID: "task"})
-	require.EqualError(t, err, "task cancelled, asset not found. taskID=task")
+	require.EqualError(t, err, "task cancelled, asset has been deleted")
 }


### PR DESCRIPTION
We were seeing lots of `error building task context` errors for one particular user, this was because they were deleting their asset immediately upon any task failures which meant any further callbacks would error on fetching the asset.

With this PR we'll now catch this specific case and return a different error which we can add to the excusable list.
