### PR TITLE
task/upload: Allow asset IPFS metadata player template on creation 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/golang/glog v1.1.0
 	github.com/julienschmidt/httprouter v1.3.0
 	github.com/livepeer/catalyst-api v0.0.13-0.20230216132322-8b4f260542df
-	github.com/livepeer/go-api-client v0.4.5
+	github.com/livepeer/go-api-client v0.4.6-0.20230321205650-846243bb0354
 	github.com/livepeer/go-tools v0.2.5
 	github.com/livepeer/joy4 v0.1.2-0.20220210094601-95e4d28f5f07
 	github.com/livepeer/livepeer-data v0.6.4

--- a/go.sum
+++ b/go.sum
@@ -95,7 +95,6 @@ github.com/gogo/protobuf v1.2.1/go.mod h1:hp+jE20tsWTFYpLwKvXlhS1hjn+gTNwPg2I6zV
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
-github.com/golang/glog v1.0.0 h1:nfP3RFugxnNRyKgeWd4oI1nYvXpxrx8ck8ZrcizshdQ=
 github.com/golang/glog v1.0.0/go.mod h1:EWib/APOK0SL3dFbYqvxE3UYd8E6s1ouQ7iEp/0LWV4=
 github.com/golang/glog v1.1.0 h1:/d3pCKDPWNnvIWe0vVUpNP32qc8U3PDVxySP/y360qE=
 github.com/golang/glog v1.1.0/go.mod h1:pfYeQZ3JWZoXTV5sFc986z3HTpwQs9At6P4ImfuP3NQ=
@@ -297,12 +296,8 @@ github.com/libp2p/go-netroute v0.2.0 h1:0FpsbsvuSnAhXFnCY0VLFbJOzaK0VnP0r1QT/o4n
 github.com/libp2p/go-openssl v0.1.0 h1:LBkKEcUv6vtZIQLVTegAil8jbNpJErQ9AnT+bWV+Ooo=
 github.com/livepeer/catalyst-api v0.0.13-0.20230216132322-8b4f260542df h1:LE308F/1nAvqN006PN1J19ZHjVXqfIye7hIckSYxR2E=
 github.com/livepeer/catalyst-api v0.0.13-0.20230216132322-8b4f260542df/go.mod h1:BA3Sk9Hta4YbWjsxL71zh6Kwd+mvHrUSfd4PSOp21xo=
-github.com/livepeer/go-api-client v0.4.3 h1:3RUYijim2qUHUZjeSV2INJ+78sWdCasULKDXzD9KlrA=
-github.com/livepeer/go-api-client v0.4.3/go.mod h1:Jdb+RI7JyzEZOHd1GUuKofwFDKMO/btTa80SdpUpYQw=
-github.com/livepeer/go-api-client v0.4.4 h1:cYq6nH2Ft90HUExbCE10FI1kOKi1Qo4cbZuX8BDF7qA=
-github.com/livepeer/go-api-client v0.4.4/go.mod h1:Jdb+RI7JyzEZOHd1GUuKofwFDKMO/btTa80SdpUpYQw=
-github.com/livepeer/go-api-client v0.4.5 h1:l57DYU/DUnP9cLDdfYOIb6hfPqJFAoThWaI9rMjH42A=
-github.com/livepeer/go-api-client v0.4.5/go.mod h1:Jdb+RI7JyzEZOHd1GUuKofwFDKMO/btTa80SdpUpYQw=
+github.com/livepeer/go-api-client v0.4.6-0.20230321205650-846243bb0354 h1:GyiiQtCggT9Q67vYHynNRkM64cOYeE37JLfJ9lN10b0=
+github.com/livepeer/go-api-client v0.4.6-0.20230321205650-846243bb0354/go.mod h1:Jdb+RI7JyzEZOHd1GUuKofwFDKMO/btTa80SdpUpYQw=
 github.com/livepeer/go-tools v0.2.5 h1:XeplmNfoPZK7mQesMQ814SUF/H+kdTubAsQR/NNTHQc=
 github.com/livepeer/go-tools v0.2.5/go.mod h1:/aZ+20XYLdeebFA3CrQTkHUf7DmiGBzh6Bs8JkbelUA=
 github.com/livepeer/joy4 v0.1.2-0.20220210094601-95e4d28f5f07 h1:ISkFQYYDgfnM6Go+VyemF66DKFc8kNoI9SwMv7GC9sM=

--- a/task/export.go
+++ b/task/export.go
@@ -98,6 +98,7 @@ func uploadFile(tctx *TaskContext, asset *api.Asset, content io.Reader) (*data.E
 			ipfs = clients.NewPinataClientAPIKey(p.APIKey, p.APISecret, extMetadata)
 		}
 	}
+
 	videoCID, metadata, err := ipfs.PinContent(tctx, "asset-"+asset.PlaybackID, contentType, content)
 	if err != nil {
 		return nil, err
@@ -106,6 +107,7 @@ func uploadFile(tctx *TaskContext, asset *api.Asset, content io.Reader) (*data.E
 	if template == api.NFTMetadataTemplatePlayer && asset.PlaybackURL == "" {
 		return nil, fmt.Errorf("cannot create player NFT for asset without playback URL")
 	}
+
 	metadataCID, err := saveNFTMetadata(tctx, ipfs, asset, videoCID, template, nftMetadata, tctx.ExportTaskConfig)
 	if err != nil {
 		return nil, err

--- a/task/export.go
+++ b/task/export.go
@@ -103,6 +103,9 @@ func uploadFile(tctx *TaskContext, asset *api.Asset, content io.Reader) (*data.E
 		return nil, err
 	}
 	template, nftMetadata := params.IPFS.NFTMetadataTemplate, params.IPFS.NFTMetadata
+	if template == api.NFTMetadataTemplatePlayer && asset.PlaybackURL == "" {
+		return nil, fmt.Errorf("cannot create player NFT for asset without playback URL")
+	}
 	metadataCID, err := saveNFTMetadata(tctx, ipfs, asset, videoCID, template, nftMetadata, tctx.ExportTaskConfig)
 	if err != nil {
 		return nil, err
@@ -122,9 +125,6 @@ func uploadFile(tctx *TaskContext, asset *api.Asset, content io.Reader) (*data.E
 func saveNFTMetadata(ctx context.Context, ipfs clients.IPFS,
 	asset *api.Asset, videoCID string, template api.NFTMetadataTemplate,
 	overrides map[string]interface{}, config ExportTaskConfig) (string, error) {
-	if template == api.NFTMetadataTemplatePlayer && asset.PlaybackURL == "" {
-		return "", fmt.Errorf("cannot create player NFT for asset without playback URL")
-	}
 	if template == "" {
 		template = api.NFTMetadataTemplateFile
 	}

--- a/task/upload.go
+++ b/task/upload.go
@@ -453,8 +453,8 @@ func complementCatalystPipeline(tctx *TaskContext, assetSpec api.AssetSpec, call
 
 	metadata.AssetSpec, metadata.CatalystResult = &assetSpec, removeCredentials(callback)
 
-	if tctx.OutputAsset.Storage.IPFS != nil {
-		ipfs := *tctx.OutputAsset.Storage.IPFS
+	if ipfsSpec := tctx.OutputAsset.Storage.IPFS; ipfsSpec != nil && ipfsSpec.Spec != nil {
+		ipfs := *ipfsSpec
 		if !FlagCatalystSupportsIPFS {
 			// TODO: Remove this branch once we have reliable catalyst IPFS support
 			var (


### PR DESCRIPTION
We had a legacy check on the export task to only allow assets with playback URLs to 
use player NFT metadata. This was because our very first assets didn't even have an HLS
playlist and just provided MP4 URLs.

For new assets creation, the only other place where `saveNFTMetadata` is called, this is not
necessary tho, as we will always create an HLS playback URL for the asset, or at least have it
playable on the player.

This fixes API-36