### PR TITLE
Humanize another invalid input error

### DIFF
--- a/task/runner.go
+++ b/task/runner.go
@@ -595,6 +595,7 @@ func humanizeCatalystError(err error) error {
 		"invalid framerate",
 		"maximum resolution is",
 		"unsupported video input",
+		"scaler position rectangle is outside output frame",
 	}
 
 	// MediaConvert pipeline errors

--- a/task/runner_test.go
+++ b/task/runner_test.go
@@ -72,6 +72,9 @@ func TestHumanizeError(t *testing.T) {
 
 	err = NewCatalystError("Unsupported video input: [High 4:4:4 Predictive profile is unsupported]", false)
 	assert.ErrorIs(humanizeError(err), errInvalidVideo)
+
+	err = NewCatalystError("external transcoder error: job failed: IP Stage runtime error on gpu [0] pipeline. [Scaler position rectangle is outside output frame ]", false)
+	assert.ErrorIs(humanizeError(err), errInvalidVideo)
 }
 
 func TestSimplePublishErrorDoesNotPanic(t *testing.T) {


### PR DESCRIPTION
We saw this error from mediaconvert for a 'bounce' variable resolution video: https://storage.googleapis.com/lp-us-catalyst-vod-com/hls/source/transfer/dfhhehfe