### PR TITLE
task: Make 4xx errors from Catalyst unretriable

### DIFF
--- a/clients/catalyst.go
+++ b/clients/catalyst.go
@@ -116,6 +116,7 @@ func (c *catalyst) UploadVOD(ctx context.Context, upload UploadVODRequest) (err 
 			rateLimitBackoff = 2 * rateLimitBackoff
 			continue
 		case <-ctx.Done():
+			err = ctx.Err()
 			return
 		}
 	}
@@ -163,4 +164,10 @@ func CatalystHookPath(apiRoot, taskId string) string {
 func isTooManyRequestsErr(err error) bool {
 	var statusErr *HTTPStatusError
 	return errors.As(err, &statusErr) && statusErr.Status == http.StatusTooManyRequests
+}
+
+func IsInputError(err error) bool {
+	var statusErr *HTTPStatusError
+	return errors.As(err, &statusErr) &&
+		(statusErr.Status >= 400 && statusErr.Status < 500)
 }

--- a/clients/catalyst.go
+++ b/clients/catalyst.go
@@ -116,7 +116,6 @@ func (c *catalyst) UploadVOD(ctx context.Context, upload UploadVODRequest) (err 
 			rateLimitBackoff = 2 * rateLimitBackoff
 			continue
 		case <-ctx.Done():
-			err = ctx.Err()
 			return
 		}
 	}

--- a/task/upload.go
+++ b/task/upload.go
@@ -83,6 +83,8 @@ func handleUploadVOD(p handleUploadVODParams) (*TaskHandlerOutput, error) {
 		err = tctx.catalyst.UploadVOD(ctx, req)
 		if errors.Is(err, clients.ErrRateLimited) {
 			nextStep = "rateLimitBackoff"
+		} else if clients.IsInputError(err) {
+			return nil, UnretriableError{fmt.Errorf("input error on catalyst request: %w", err)}
 		} else if err != nil {
 			return nil, fmt.Errorf("failed to call catalyst: %w", err)
 		}


### PR DESCRIPTION
This is to improve our error classification and both not retry as well as not alert from user-input errors on the request to Catalyst (normally bad input URLs).