### PR TITLE
task: Fix progress reporting step

### DIFF
--- a/task/progress.go
+++ b/task/progress.go
@@ -39,6 +39,7 @@ func NewProgressReporter(ctx context.Context, lapi *api.Client, taskID, step str
 		cancel: cancel,
 		lapi:   lapi,
 		taskID: taskID,
+		step:   step,
 	}
 	go p.mainLoop()
 	return p


### PR DESCRIPTION
We were getting the constructor arg and sending it in all progress update requests, but it was actually never saved in the struct.

This fixes that (API-42)