### PR TITLE
Fix IPFS export for recordings

### DIFF
--- a/task/export.go
+++ b/task/export.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net/url"
+	"path"
 	"strings"
 
 	"github.com/golang/glog"
@@ -47,7 +48,7 @@ func TaskExport(tctx *TaskContext) (*TaskHandlerOutput, error) {
 		return nil, fmt.Errorf("unable to find download filename for asset: %s", asset.ID)
 	}
 
-	file, err := osSess.ReadData(ctx, downloadFile)
+	file, err := osSess.ReadData(ctx, path.Join(asset.PlaybackID, downloadFile))
 	if err != nil {
 		return nil, err
 	}

--- a/task/export.go
+++ b/task/export.go
@@ -33,7 +33,21 @@ func TaskExport(tctx *TaskContext) (*TaskHandlerOutput, error) {
 		size   = asset.Size
 		osSess = tctx.inputOS
 	)
-	file, err := osSess.ReadData(ctx, videoFileName(asset.PlaybackID))
+	downloadFile := ""
+	for _, file := range asset.Files {
+		if file.Type == "static_transcoded_mp4" {
+			downloadFile = file.Path
+			if strings.HasSuffix(asset.DownloadURL, file.Path) {
+				// we've found an exact match to the download URL so exit the loop
+				break
+			}
+		}
+	}
+	if downloadFile == "" {
+		return nil, fmt.Errorf("unable to find download filename for asset: %s", asset.ID)
+	}
+
+	file, err := osSess.ReadData(ctx, downloadFile)
 	if err != nil {
 		return nil, err
 	}

--- a/task/export.go
+++ b/task/export.go
@@ -36,7 +36,7 @@ func TaskExport(tctx *TaskContext) (*TaskHandlerOutput, error) {
 	)
 	downloadFile := ""
 	for _, file := range asset.Files {
-		if file.Type == "static_transcoded_mp4" {
+		if file.Type == "static_transcoded_mp4" || file.Type == "source_file" {
 			downloadFile = file.Path
 			if strings.HasSuffix(asset.DownloadURL, file.Path) {
 				// we've found an exact match to the download URL so exit the loop


### PR DESCRIPTION
Previously we were assuming the source file `video` would always be available, but for recordings this doesn't get generated. To fix we now check for a static mp4 output as well as the `video` file (mp4s are always generated for recordings https://github.com/livepeer/task-runner/blob/d7580fa/task/upload.go#L525).