### PR TITLE
Enable catalyst source copying

### DIFF
--- a/task/import.go
+++ b/task/import.go
@@ -97,7 +97,7 @@ func TaskImport(tctx *TaskContext) (*TaskHandlerOutput, error) {
 
 func getFile(ctx context.Context, osSess drivers.OSSession, cfg ImportTaskConfig, params api.UploadTaskParams, vodDecryptPrivateKey string) (name string, size uint64, content io.ReadCloser, err error) {
 	name, size, content, err = getFileRaw(ctx, osSess, cfg, params)
-	if err != nil || params.Encryption.EncryptedKey == "" {
+	if err != nil || !isEncryptionEnabled(params) {
 		return
 	}
 

--- a/task/upload.go
+++ b/task/upload.go
@@ -457,7 +457,7 @@ func complementCatalystPipeline(tctx *TaskContext, assetSpec api.AssetSpec, call
 
 	if !catalystCopiedSource {
 		// in case of encrypted input, file will have been copied in the beginning
-		if params.Encryption.EncryptedKey == "" {
+		if !isEncryptionEnabled(params) {
 			input, err := readLocalFile(0.95)
 			if err != nil {
 				return nil, err
@@ -525,6 +525,10 @@ func isHLSFile(fname string) bool {
 	return fname[ext:] == ".m3u8"
 }
 
+func isEncryptionEnabled(params api.UploadTaskParams) bool {
+	return params.Encryption.EncryptedKey != ""
+}
+
 func uploadTaskOutputLocations(tctx *TaskContext) ([]OutputName, []clients.OutputLocation, error) {
 	playbackId := tctx.OutputAsset.PlaybackID
 	outURL := tctx.OutputOSObj.URL
@@ -534,7 +538,7 @@ func uploadTaskOutputLocations(tctx *TaskContext) ([]OutputName, []clients.Outpu
 	} else {
 		mp4 = OUTPUT_ONLY_SHORT
 	}
-	outputNames, outputLocations, err := outputLocations(outURL, OUTPUT_ENABLED, playbackId, mp4, playbackId, true)
+	outputNames, outputLocations, err := outputLocations(outURL, OUTPUT_ENABLED, playbackId, mp4, playbackId, !isEncryptionEnabled(*tctx.Task.Params.Upload))
 	if err != nil {
 		return nil, nil, err
 	}

--- a/task/upload_test.go
+++ b/task/upload_test.go
@@ -160,6 +160,7 @@ func TestOutputLocations(t *testing.T) {
 		hlsRelPath              string
 		mp4                     string
 		mp4RelPath              string
+		sourceCopy              bool
 		expectedOutputLocations []clients.OutputLocation
 		hasError                bool
 	}{
@@ -211,10 +212,42 @@ func TestOutputLocations(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:       "HLS and Short Video MP4",
+			outURL:     "s3+https://user:pass@host.com/outbucket",
+			hls:        "enabled",
+			hlsRelPath: "video/hls",
+			mp4:        "only_short",
+			mp4RelPath: "video/mp4",
+			sourceCopy: true,
+			expectedOutputLocations: []clients.OutputLocation{
+				{
+					Type: "object_store",
+					URL:  "s3+https://user:pass@host.com/outbucket/video/hls",
+					Outputs: &clients.OutputsRequest{
+						HLS: "enabled",
+					},
+				},
+				{
+					Type: "object_store",
+					URL:  "s3+https://user:pass@host.com/outbucket/video/mp4",
+					Outputs: &clients.OutputsRequest{
+						MP4: "only_short",
+					},
+				},
+				{
+					Type: "object_store",
+					URL:  "s3+https://user:pass@host.com/outbucket/video/hls/video",
+					Outputs: &clients.OutputsRequest{
+						SourceMp4: true,
+					},
+				},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, gotOutputLocations, err := outputLocations(tt.outURL, tt.hls, tt.hlsRelPath, tt.mp4, tt.mp4RelPath)
+			_, gotOutputLocations, err := outputLocations(tt.outURL, tt.hls, tt.hlsRelPath, tt.mp4, tt.mp4RelPath, tt.sourceCopy)
 
 			if tt.hasError {
 				require.Error(t, err)


### PR DESCRIPTION
- This enables source copying at catalyst for upload tasks (and not transcode-file) by setting the SourceMp4 flag on the catalyst request.
- Removed unused function `removeCredentials`