### PR TITLE
Don't reject audio-only VOD assets

### DIFF
--- a/task/probe.go
+++ b/task/probe.go
@@ -98,9 +98,6 @@ func toAssetSpec(filename string, strict bool, probeData *ffprobe.ProbeData, siz
 		hasAudio = hasAudio || track.Type == "audio"
 		spec.VideoSpec.Tracks = append(spec.VideoSpec.Tracks, track)
 	}
-	if !hasVideo {
-		return nil, fmt.Errorf("no video track found in file")
-	}
 	if !hasAudio && strict {
 		return nil, fmt.Errorf("no audio track found in file")
 	}

--- a/task/runner.go
+++ b/task/runner.go
@@ -613,7 +613,6 @@ func humanizeCatalystError(err error) error {
 		// Keeping it simple for now and returning errInvalidVideo for this
 		// But, should there be a separate humanized error for this?
 		"readpacketdata file read failed - end of file hit",
-		"no video track found in file",
 		"no pictures decoded",
 		"zero bytes found for source",
 		"invalid framerate",

--- a/task/runner_test.go
+++ b/task/runner_test.go
@@ -49,9 +49,6 @@ func TestHumanizeError(t *testing.T) {
 	err = NewCatalystError("foobar Failed probe/open: foobar", false)
 	assert.ErrorIs(humanizeError(err), errProbe)
 
-	err = NewCatalystError("no video track found in file", false)
-	assert.ErrorIs(humanizeError(err), errInvalidVideo)
-
 	err = NewCatalystError("job failed: Decoder closed. No pictures decoded", false)
 	assert.ErrorIs(humanizeError(err), errInvalidVideo)
 


### PR DESCRIPTION
This is now supported in Catalyst API with https://github.com/livepeer/catalyst-api/pull/843