### PR TITLE
Disable transcoder fallback for clips

### DIFF
--- a/task/upload.go
+++ b/task/upload.go
@@ -278,7 +278,7 @@ func TaskClip(tctx *TaskContext) (*TaskHandlerOutput, error) {
 				TaskOutput: &data.TaskOutput{Clip: taskOutput},
 			}, nil
 		},
-		catalystPipelineStrategy: pipeline.Strategy(params.CatalystPipelineStrategy),
+		catalystPipelineStrategy: pipeline.StrategyCatalystFfmpegDominance,
 		clipStrategy: clients.ClipStrategy{
 			StartTime:  params.ClipStrategy.StartTime,
 			EndTime:    params.ClipStrategy.EndTime,


### PR DESCRIPTION
For the same reason as recordings, these will be supported codecs so we shouldn't fall back to external transcoder