### PR TITLE
clients/catalyst: Allow empty profiles to be sent on upload req

### DIFF
--- a/clients/catalyst.go
+++ b/clients/catalyst.go
@@ -40,7 +40,7 @@ type UploadVODRequest struct {
 	Url                   string             `json:"url"`
 	CallbackUrl           string             `json:"callback_url"`
 	OutputLocations       []OutputLocation   `json:"output_locations,omitempty"`
-	Profiles              []api.Profile      `json:"profiles,omitempty"`
+	Profiles              *[]api.Profile     `json:"profiles,omitempty"`
 	PipelineStrategy      pipeline.Strategy  `json:"pipeline_strategy,omitempty"`
 	TargetSegmentSizeSecs int64              `json:"target_segment_size_secs,omitempty"`
 	Encryption            *EncryptionPayload `json:"encryption,omitempty"`

--- a/clients/catalyst.go
+++ b/clients/catalyst.go
@@ -120,7 +120,7 @@ func (c *catalyst) UploadVOD(ctx context.Context, upload UploadVODRequest) (err 
 			Body:        bytes.NewReader(body),
 			ContentType: "application/json",
 		}, &res)
-		glog.Infof("Catalyst upload VOD request: req=%v err=%s res=%s", withoutCredentials(upload), err, string(res))
+		glog.Infof("Catalyst upload VOD request: req=%q err=%s res=%s", withoutCredentials(upload), err, string(res))
 
 		if !isTooManyRequestsErr(err) {
 			return
@@ -140,7 +140,7 @@ func (c *catalyst) UploadVOD(ctx context.Context, upload UploadVODRequest) (err 
 	}
 }
 
-func withoutCredentials(upload UploadVODRequest) UploadVODRequest {
+func withoutCredentials(upload UploadVODRequest) string {
 	res := upload
 	res.Url = RedactURL(upload.Url)
 	res.OutputLocations = []OutputLocation{}
@@ -149,7 +149,11 @@ func withoutCredentials(upload UploadVODRequest) UploadVODRequest {
 		nol.URL = RedactURL(ol.URL)
 		res.OutputLocations = append(res.OutputLocations, nol)
 	}
-	return res
+	jsonBytes, err := json.Marshal(res)
+	if err != nil {
+		return fmt.Sprintf("marshal error: %s", err)
+	}
+	return string(jsonBytes)
 }
 
 func RedactURL(urlStr string) string {

--- a/clients/catalyst_test.go
+++ b/clients/catalyst_test.go
@@ -109,21 +109,15 @@ func TestCatalystRateLimiting(t *testing.T) {
 }
 
 func TestWithoutCredentials(t *testing.T) {
-	require.Equal(t, UploadVODRequest{
-		Url: "s3+https://jv4s7zwfugeb7uccnnl2bwigikka:xxxxx@gateway.storjshare.io/inbucket/source.mp4",
-		OutputLocations: []OutputLocation{
-			{
-				Type: "object_store",
-				URL:  "s3+https://jv4s7zwfugeb7uccnnl2bwigikka:xxxxx@gateway.storjshare.io/outbucket/sourcetest/hls/index.m3u8",
+	require.Equal(t,
+		`{"url":"s3+https://jv4s7zwfugeb7uccnnl2bwigikka:xxxxx@gateway.storjshare.io/inbucket/source.mp4","callback_url":"","output_locations":[{"type":"object_store","url":"s3+https://jv4s7zwfugeb7uccnnl2bwigikka:xxxxx@gateway.storjshare.io/outbucket/sourcetest/hls/index.m3u8"}],"clip_strategy":{}}`,
+		withoutCredentials(UploadVODRequest{
+			Url: "s3+https://jv4s7zwfugeb7uccnnl2bwigikka:j3axkol3vqndxy4vs6mgmv4tzs47kaxazj3uesegybny2q7n74jwq@gateway.storjshare.io/inbucket/source.mp4",
+			OutputLocations: []OutputLocation{
+				{
+					Type: "object_store",
+					URL:  "s3+https://jv4s7zwfugeb7uccnnl2bwigikka:j3axkol3vqndxy4vs6mgmv4tzs47kaxazj3uesegybny2q7n74jwq@gateway.storjshare.io/outbucket/sourcetest/hls/index.m3u8",
+				},
 			},
-		},
-	}, withoutCredentials(UploadVODRequest{
-		Url: "s3+https://jv4s7zwfugeb7uccnnl2bwigikka:j3axkol3vqndxy4vs6mgmv4tzs47kaxazj3uesegybny2q7n74jwq@gateway.storjshare.io/inbucket/source.mp4",
-		OutputLocations: []OutputLocation{
-			{
-				Type: "object_store",
-				URL:  "s3+https://jv4s7zwfugeb7uccnnl2bwigikka:j3axkol3vqndxy4vs6mgmv4tzs47kaxazj3uesegybny2q7n74jwq@gateway.storjshare.io/outbucket/sourcetest/hls/index.m3u8",
-			},
-		},
-	}))
+		}))
 }

--- a/task/upload.go
+++ b/task/upload.go
@@ -101,10 +101,13 @@ func handleUploadVOD(p handleUploadVODParams) (*TaskHandlerOutput, error) {
 			CallbackUrl:           tctx.catalyst.CatalystHookURL(tctx.Task.ID, "finalize", catalystTaskAttemptID(tctx.Task)),
 			OutputLocations:       outputLocations,
 			PipelineStrategy:      p.catalystPipelineStrategy,
-			Profiles:              p.profiles,
 			TargetSegmentSizeSecs: p.targetSegmentSizeSecs,
 			Encryption:            encryption,
 			C2PA:                  p.c2pa,
+		}
+
+		if p.profiles != nil {
+			req.Profiles = &p.profiles
 		}
 
 		if clipStrategy != nil {


### PR DESCRIPTION
In order to allow no transcoding for recordings, we'll need to send an empty profiles array
so that only the "copy" profile is used (https://github.com/livepeer/catalyst-api/pull/1261).

